### PR TITLE
chore: move events and contexts into separate files

### DIFF
--- a/src/ContextManager.ts
+++ b/src/ContextManager.ts
@@ -3,7 +3,7 @@
  * See COPYING.txt for license details.
  */
 
-import { Base } from "./base";
+import { Base } from "./Base";
 import contexts from "./contexts";
 import {
     MagentoExtension,

--- a/src/ContextManager.ts
+++ b/src/ContextManager.ts
@@ -3,20 +3,8 @@
  * See COPYING.txt for license details.
  */
 
-import {
-    MAGENTO_EXTENSION_CONTEXT,
-    PAGE_OFFSET_CONTEXT,
-    ORDER_CONTEXT,
-    PRODUCT_CONTEXT,
-    SEARCH_INPUT_CONTEXT,
-    SEARCH_RESULTS_CONTEXT,
-    SHOPPER_CONTEXT,
-    SHOPPING_CART_CONTEXT,
-    STOREFRONT_INSTANCE_CONTEXT,
-    CUSTOM_URL_CONTEXT,
-    REFERRER_URL_CONTEXT,
-} from "./types/contexts";
-import { Base } from "./Base";
+import { Base } from "./base";
+import contexts from "./contexts";
 import {
     MagentoExtension,
     PageOffset,
@@ -36,147 +24,157 @@ export default class ContextManager extends Base {
      * Get url context
      */
     getCustomUrl(): CustomUrl {
-        return this.getContext<CustomUrl>(CUSTOM_URL_CONTEXT);
+        return this.getContext<CustomUrl>(contexts.CUSTOM_URL_CONTEXT);
     }
 
     /**
      * Set url context
      */
     setCustomUrl(context: CustomUrl): void {
-        this.setContext<CustomUrl>(CUSTOM_URL_CONTEXT, context);
+        this.setContext<CustomUrl>(contexts.CUSTOM_URL_CONTEXT, context);
     }
 
     /**
      * Get shopper context
      **/
     getShopper(): Shopper {
-        return this.getContext<Shopper>(SHOPPER_CONTEXT);
+        return this.getContext<Shopper>(contexts.SHOPPER_CONTEXT);
     }
 
     /**
      * Set shopper context
      **/
     setShopper(context: Shopper): void {
-        this.setContext<Shopper>(SHOPPER_CONTEXT, context);
+        this.setContext<Shopper>(contexts.SHOPPER_CONTEXT, context);
     }
 
     /**
      * Get Magento extension context
      */
     getMagentoExtension(): MagentoExtension {
-        return this.getContext<MagentoExtension>(MAGENTO_EXTENSION_CONTEXT);
+        return this.getContext<MagentoExtension>(
+            contexts.MAGENTO_EXTENSION_CONTEXT,
+        );
     }
 
     /**
      * Set Magento extension context
      */
     setMagentoExtension(context: MagentoExtension): void {
-        this.setContext<MagentoExtension>(MAGENTO_EXTENSION_CONTEXT, context);
+        this.setContext<MagentoExtension>(
+            contexts.MAGENTO_EXTENSION_CONTEXT,
+            context,
+        );
     }
 
     /**
      * Get order context
      */
     getOrder(): Order {
-        return this.getContext<Order>(ORDER_CONTEXT);
+        return this.getContext<Order>(contexts.ORDER_CONTEXT);
     }
 
     /**
      * Set order context
      */
     setOrder(context: Order): void {
-        this.setContext<Order>(ORDER_CONTEXT, context);
+        this.setContext<Order>(contexts.ORDER_CONTEXT, context);
     }
 
     /**
      * Get page offset context
      */
     getPageOffset(): PageOffset {
-        return this.getContext<PageOffset>(PAGE_OFFSET_CONTEXT);
+        return this.getContext<PageOffset>(contexts.PAGE_OFFSET_CONTEXT);
     }
 
     /**
      * Set page offset context
      */
     setPageOffset(context: PageOffset): void {
-        this.setContext<PageOffset>(PAGE_OFFSET_CONTEXT, context);
+        this.setContext<PageOffset>(contexts.PAGE_OFFSET_CONTEXT, context);
     }
 
     /**
      * Get product context
      */
     getProduct(): Product {
-        return this.getContext<Product>(PRODUCT_CONTEXT);
+        return this.getContext<Product>(contexts.PRODUCT_CONTEXT);
     }
 
     /**
      * Set product context
      */
     setProduct(context: Product): void {
-        this.setContext<Product>(PRODUCT_CONTEXT, context);
+        this.setContext<Product>(contexts.PRODUCT_CONTEXT, context);
     }
 
     /**
      * Get referrer url context
      */
     getReferrerUrl(): ReferrerUrl {
-        return this.getContext<ReferrerUrl>(REFERRER_URL_CONTEXT);
+        return this.getContext<ReferrerUrl>(contexts.REFERRER_URL_CONTEXT);
     }
 
     /**
      * Set referrer url context
      */
     setReferrerUrl(context: ReferrerUrl): void {
-        this.setContext<ReferrerUrl>(REFERRER_URL_CONTEXT, context);
+        this.setContext<ReferrerUrl>(contexts.REFERRER_URL_CONTEXT, context);
     }
 
     /**
      * Get search input context
      */
     getSearchInput(): SearchInput {
-        return this.getContext<SearchInput>(SEARCH_INPUT_CONTEXT);
+        return this.getContext<SearchInput>(contexts.SEARCH_INPUT_CONTEXT);
     }
 
     /**
      * Set search input context
      */
     setSearchInput(context: SearchInput): void {
-        this.setContext<SearchInput>(SEARCH_INPUT_CONTEXT, context);
+        this.setContext<SearchInput>(contexts.SEARCH_INPUT_CONTEXT, context);
     }
 
     /**
      * Get search results context
      */
     getSearchResults(): SearchResults {
-        return this.getContext<SearchResults>(SEARCH_RESULTS_CONTEXT);
+        return this.getContext<SearchResults>(contexts.SEARCH_RESULTS_CONTEXT);
     }
 
     /**
      * Set search results context
      */
     setSearchResults(context: SearchResults): void {
-        this.setContext<SearchResults>(SEARCH_RESULTS_CONTEXT, context);
+        this.setContext<SearchResults>(
+            contexts.SEARCH_RESULTS_CONTEXT,
+            context,
+        );
     }
 
     /**
      * Get shopping cart context
      */
     getShoppingCart(): ShoppingCart {
-        return this.getContext<ShoppingCart>(SHOPPING_CART_CONTEXT);
+        return this.getContext<ShoppingCart>(contexts.SHOPPING_CART_CONTEXT);
     }
 
     /**
      * Set shopping cart context
      */
     setShoppingCart(context: ShoppingCart): void {
-        this.setContext<ShoppingCart>(SHOPPING_CART_CONTEXT, context);
+        this.setContext<ShoppingCart>(contexts.SHOPPING_CART_CONTEXT, context);
     }
 
     /**
      * Get storefront instance context
      */
     getStorefrontInstance(): StorefrontInstance {
-        return this.getContext<StorefrontInstance>(STOREFRONT_INSTANCE_CONTEXT);
+        return this.getContext<StorefrontInstance>(
+            contexts.STOREFRONT_INSTANCE_CONTEXT,
+        );
     }
 
     /**
@@ -185,7 +183,7 @@ export default class ContextManager extends Base {
      */
     setStorefrontInstance(context: StorefrontInstance): void {
         this.setContext<StorefrontInstance>(
-            STOREFRONT_INSTANCE_CONTEXT,
+            contexts.STOREFRONT_INSTANCE_CONTEXT,
             context,
         );
     }

--- a/src/MagentoStorefrontEvents.ts
+++ b/src/MagentoStorefrontEvents.ts
@@ -3,10 +3,10 @@
  * See COPYING.txt for license details.
  */
 
-import ContextManager from "./contextManager";
-import PublishManager from "./publishManager";
-import SubscribeManager from "./subscribeManager";
-import UnsubscribeManager from "./unsubscribeManager";
+import ContextManager from "./ContextManager";
+import PublishManager from "./PublishManager";
+import SubscribeManager from "./SubscribeManager";
+import UnsubscribeManager from "./UnsubscribeManager";
 
 class MagentoStorefrontEvents {
     constructor() {

--- a/src/PublishManager.ts
+++ b/src/PublishManager.ts
@@ -3,30 +3,8 @@
  * See COPYING.txt for license details.
  */
 
-import {
-    ADD_TO_CART,
-    CUSTOM_URL,
-    INITIATE_CHECKOUT,
-    PAGE_ACTIVITY_SUMMARY,
-    PAGE_VIEW,
-    PLACE_ORDER,
-    PRODUCT_PAGE_VIEW,
-    RECS_ITEM_ADD_TO_CART_CLICK,
-    RECS_ITEM_CLICK,
-    RECS_REQUEST_SENT,
-    RECS_RESPONSE_RECEIVED,
-    RECS_UNIT_RENDER,
-    RECS_UNIT_VIEW,
-    REFERRER_URL,
-    REMOVE_FROM_CART,
-    SEARCH_REQUEST_SENT,
-    SEARCH_RESPONSE_RECEIVED,
-    SEARCH_RESULT_CLICK,
-    SIGN_IN,
-    SIGN_OUT,
-    UPDATE_CART,
-} from "./types/events";
-import { Base } from "./Base";
+import { Base } from "./base";
+import events from "./events";
 import { CustomContext } from "./types/contexts";
 
 export default class PublishManager extends Base {
@@ -34,146 +12,146 @@ export default class PublishManager extends Base {
      * Publish Add to Cart event
      */
     addToCart(context?: CustomContext): void {
-        this.pushEvent(ADD_TO_CART, context);
+        this.pushEvent(events.ADD_TO_CART, context);
     }
 
     /**
      * Publish Custom Url event
      */
     customUrl(context?: CustomContext): void {
-        this.pushEvent(CUSTOM_URL, context);
+        this.pushEvent(events.CUSTOM_URL, context);
     }
 
     /**
      * Publish Initiate Checkout event
      */
     initiateCheckout(context?: CustomContext): void {
-        this.pushEvent(INITIATE_CHECKOUT, context);
+        this.pushEvent(events.INITIATE_CHECKOUT, context);
     }
 
     /**
      * Publish Page Activity Summary event
      */
     pageActivitySummary(context?: CustomContext): void {
-        this.pushEvent(PAGE_ACTIVITY_SUMMARY, context);
+        this.pushEvent(events.PAGE_ACTIVITY_SUMMARY, context);
     }
 
     /**
      * Publish Page View event
      */
     pageView(context?: CustomContext): void {
-        this.pushEvent(PAGE_VIEW, context);
+        this.pushEvent(events.PAGE_VIEW, context);
     }
 
     /**
      * Publish Place Order event
      */
     placeOrder(context?: CustomContext): void {
-        this.pushEvent(PLACE_ORDER, context);
+        this.pushEvent(events.PLACE_ORDER, context);
     }
 
     /**
      * Publish Product Page View event
      */
     productPageView(context?: CustomContext): void {
-        this.pushEvent(PRODUCT_PAGE_VIEW, context);
+        this.pushEvent(events.PRODUCT_PAGE_VIEW, context);
     }
 
     /**
      * Publish Recommended Item Add to Cart Click event
      */
     recsItemAddToCartClick(context?: CustomContext): void {
-        this.pushEvent(RECS_ITEM_ADD_TO_CART_CLICK, context);
+        this.pushEvent(events.RECS_ITEM_ADD_TO_CART_CLICK, context);
     }
 
     /**
      * Publish Recommended Item Click event
      */
     recsItemClick(context?: CustomContext): void {
-        this.pushEvent(RECS_ITEM_CLICK, context);
+        this.pushEvent(events.RECS_ITEM_CLICK, context);
     }
 
     /**
      * Publish Recommendations API Request event
      */
     recsRequestSent(context?: CustomContext): void {
-        this.pushEvent(RECS_REQUEST_SENT, context);
+        this.pushEvent(events.RECS_REQUEST_SENT, context);
     }
 
     /**
      * Publish Recommendations Response Received event
      */
     recsResponseReceived(context?: CustomContext): void {
-        this.pushEvent(RECS_RESPONSE_RECEIVED, context);
+        this.pushEvent(events.RECS_RESPONSE_RECEIVED, context);
     }
 
     /**
      * Publish Recommended Unit Render Event
      */
     recsUnitRender(context?: CustomContext): void {
-        this.pushEvent(RECS_UNIT_RENDER, context);
+        this.pushEvent(events.RECS_UNIT_RENDER, context);
     }
 
     /**
      * Publish Recommended Unit View event
      */
     recsUnitView(context?: CustomContext): void {
-        this.pushEvent(RECS_UNIT_VIEW, context);
+        this.pushEvent(events.RECS_UNIT_VIEW, context);
     }
 
     /**
      * Publish Referrer Url event
      */
     referrerUrl(context?: CustomContext): void {
-        this.pushEvent(REFERRER_URL, context);
+        this.pushEvent(events.REFERRER_URL, context);
     }
 
     /**
      * Publish Remove from Cart event
      */
     removeFromCart(context?: CustomContext): void {
-        this.pushEvent(REMOVE_FROM_CART, context);
+        this.pushEvent(events.REMOVE_FROM_CART, context);
     }
 
     /**
      * Publish Search Request Sent event
      */
     searchRequestSent(context?: CustomContext): void {
-        this.pushEvent(SEARCH_REQUEST_SENT, context);
+        this.pushEvent(events.SEARCH_REQUEST_SENT, context);
     }
 
     /**
      * Publish Search Response Received event
      */
     searchResponseReceived(context?: CustomContext): void {
-        this.pushEvent(SEARCH_RESPONSE_RECEIVED, context);
+        this.pushEvent(events.SEARCH_RESPONSE_RECEIVED, context);
     }
 
     /**
      * Publish Search Result Click event
      */
     searchResultClick(context?: CustomContext): void {
-        this.pushEvent(SEARCH_RESULT_CLICK, context);
+        this.pushEvent(events.SEARCH_RESULT_CLICK, context);
     }
 
     /**
      * Publish Sign In event
      */
     signIn(context?: CustomContext): void {
-        this.pushEvent(SIGN_IN, context);
+        this.pushEvent(events.SIGN_IN, context);
     }
 
     /**
      * Publish Sign Out event
      */
     signOut(context?: CustomContext): void {
-        this.pushEvent(SIGN_OUT, context);
+        this.pushEvent(events.SIGN_OUT, context);
     }
 
     /**
      * Publish Cart Update events
      */
     updateCart(context?: CustomContext): void {
-        this.pushEvent(UPDATE_CART, context);
+        this.pushEvent(events.UPDATE_CART, context);
     }
 }

--- a/src/PublishManager.ts
+++ b/src/PublishManager.ts
@@ -3,7 +3,7 @@
  * See COPYING.txt for license details.
  */
 
-import { Base } from "./base";
+import { Base } from "./Base";
 import events from "./events";
 import { CustomContext } from "./types/contexts";
 

--- a/src/SubscribeManager.ts
+++ b/src/SubscribeManager.ts
@@ -3,70 +3,44 @@
  * See COPYING.txt for license details.
  */
 
-import { Base } from "./Base";
-
-import {
-    ADD_TO_CART,
-    CUSTOM_URL,
-    DATA_LAYER_CHANGE,
-    DATA_LAYER_EVENT,
-    INITIATE_CHECKOUT,
-    ListenerOptions,
-    EventHandler,
-    PAGE_ACTIVITY_SUMMARY,
-    PAGE_VIEW,
-    PLACE_ORDER,
-    PRODUCT_PAGE_VIEW,
-    RECS_ITEM_ADD_TO_CART_CLICK,
-    RECS_ITEM_CLICK,
-    RECS_REQUEST_SENT,
-    RECS_RESPONSE_RECEIVED,
-    RECS_UNIT_RENDER,
-    RECS_UNIT_VIEW,
-    REFERRER_URL,
-    REMOVE_FROM_CART,
-    SEARCH_REQUEST_SENT,
-    SEARCH_RESPONSE_RECEIVED,
-    SEARCH_RESULT_CLICK,
-    SIGN_IN,
-    SIGN_OUT,
-    UPDATE_CART,
-} from "./types/events";
+import { Base } from "./base";
+import events from "./events";
+import { ListenerOptions, EventHandler } from "./types/events";
 
 export default class SubscribeManager extends Base {
     /**
      * Subscribe to Add to Cart event
      */
     addToCart(handler: EventHandler, options?: ListenerOptions): void {
-        this.addEventListener(ADD_TO_CART, handler, options);
+        this.addEventListener(events.ADD_TO_CART, handler, options);
     }
 
     /**
      * Subscribe to Custom Url event
      */
     customUrl(handler: EventHandler, options?: ListenerOptions): void {
-        this.addEventListener(CUSTOM_URL, handler, options);
+        this.addEventListener(events.CUSTOM_URL, handler, options);
     }
 
     /**
      * Subscribe to changes on the data layer
      */
     dataLayerChange(handler: EventHandler, options?: ListenerOptions): void {
-        this.addEventListener(DATA_LAYER_CHANGE, handler, options);
+        this.addEventListener(events.DATA_LAYER_CHANGE, handler, options);
     }
 
     /**
      * Subscribe to all events on the data layer
      */
     dataLayerEvent(handler: EventHandler, options?: ListenerOptions): void {
-        this.addEventListener(DATA_LAYER_EVENT, handler, options);
+        this.addEventListener(events.DATA_LAYER_EVENT, handler, options);
     }
 
     /**
      * Subscribe to Initiate Checkout event
      */
     initiateCheckout(handler: EventHandler, options?: ListenerOptions): void {
-        this.addEventListener(INITIATE_CHECKOUT, handler, options);
+        this.addEventListener(events.INITIATE_CHECKOUT, handler, options);
     }
 
     /**
@@ -76,28 +50,28 @@ export default class SubscribeManager extends Base {
         handler: EventHandler,
         options?: ListenerOptions,
     ): void {
-        this.addEventListener(PAGE_ACTIVITY_SUMMARY, handler, options);
+        this.addEventListener(events.PAGE_ACTIVITY_SUMMARY, handler, options);
     }
 
     /**
      * Subscribe to Page View event
      */
     pageView(handler: EventHandler, options?: ListenerOptions): void {
-        this.addEventListener(PAGE_VIEW, handler, options);
+        this.addEventListener(events.PAGE_VIEW, handler, options);
     }
 
     /**
      * Subscribe to Place Order event
      */
     placeOrder(handler: EventHandler, options?: ListenerOptions): void {
-        this.addEventListener(PLACE_ORDER, handler, options);
+        this.addEventListener(events.PLACE_ORDER, handler, options);
     }
 
     /**
      * Subscribe to Product Page View event
      */
     productPageView(handler: EventHandler, options?: ListenerOptions): void {
-        this.addEventListener(PRODUCT_PAGE_VIEW, handler, options);
+        this.addEventListener(events.PRODUCT_PAGE_VIEW, handler, options);
     }
 
     /**
@@ -107,21 +81,25 @@ export default class SubscribeManager extends Base {
         handler: EventHandler,
         options?: ListenerOptions,
     ): void {
-        this.addEventListener(RECS_ITEM_ADD_TO_CART_CLICK, handler, options);
+        this.addEventListener(
+            events.RECS_ITEM_ADD_TO_CART_CLICK,
+            handler,
+            options,
+        );
     }
 
     /**
      * Subscribe to Recommended Item Click event
      */
     recsItemClick(handler: EventHandler, options?: ListenerOptions): void {
-        this.addEventListener(RECS_ITEM_CLICK, handler, options);
+        this.addEventListener(events.RECS_ITEM_CLICK, handler, options);
     }
 
     /**
      * Subscribe to Recommendations API Request event
      */
     recsRequestSent(handler: EventHandler, options?: ListenerOptions): void {
-        this.addEventListener(RECS_REQUEST_SENT, handler, options);
+        this.addEventListener(events.RECS_REQUEST_SENT, handler, options);
     }
 
     /**
@@ -131,76 +109,76 @@ export default class SubscribeManager extends Base {
         handler: EventHandler,
         options?: ListenerOptions,
     ): void {
-        this.addEventListener(RECS_RESPONSE_RECEIVED, handler, options);
+        this.addEventListener(events.RECS_RESPONSE_RECEIVED, handler, options);
     }
 
     /**
      * Subscribe to Recommended Unit Render Event
      */
     recsUnitRender(handler: EventHandler, options?: ListenerOptions): void {
-        this.addEventListener(RECS_UNIT_RENDER, handler, options);
+        this.addEventListener(events.RECS_UNIT_RENDER, handler, options);
     }
 
     /**
      * Subscribe to Recommended Unit View event
      */
     recsUnitView(handler: EventHandler, options?: ListenerOptions): void {
-        this.addEventListener(RECS_UNIT_VIEW, handler, options);
+        this.addEventListener(events.RECS_UNIT_VIEW, handler, options);
     }
 
     /**
      * Subscribe to Referrer Url event
      */
     referrerUrl(handler: EventHandler, options?: ListenerOptions): void {
-        this.addEventListener(REFERRER_URL, handler, options);
+        this.addEventListener(events.REFERRER_URL, handler, options);
     }
 
     /**
      * Subscribe to Remove from Cart event
      */
     removeFromCart(handler: EventHandler, options?: ListenerOptions): void {
-        this.addEventListener(REMOVE_FROM_CART, handler, options);
+        this.addEventListener(events.REMOVE_FROM_CART, handler, options);
     }
 
     /**
      * Subscribe to Search Request Sent event
      */
     searchRequestSent(handler: EventHandler): void {
-        this.addEventListener(SEARCH_REQUEST_SENT, handler);
+        this.addEventListener(events.SEARCH_REQUEST_SENT, handler);
     }
 
     /**
      * Subscribe to Search Response Received event
      */
     searchResponseReceived(handler: EventHandler): void {
-        this.addEventListener(SEARCH_RESPONSE_RECEIVED, handler);
+        this.addEventListener(events.SEARCH_RESPONSE_RECEIVED, handler);
     }
 
     /**
      * Subscribe to Search Result Click event
      */
     searchResultClick(handler: EventHandler): void {
-        this.addEventListener(SEARCH_RESULT_CLICK, handler);
+        this.addEventListener(events.SEARCH_RESULT_CLICK, handler);
     }
 
     /**
      * Subscribe to Sign In event
      */
     signIn(handler: EventHandler, options?: ListenerOptions): void {
-        this.addEventListener(SIGN_IN, handler, options);
+        this.addEventListener(events.SIGN_IN, handler, options);
     }
 
     /**
      * Subscribe to Sign Out event
      */
     signOut(handler: EventHandler, options?: ListenerOptions): void {
-        this.addEventListener(SIGN_OUT, handler, options);
+        this.addEventListener(events.SIGN_OUT, handler, options);
     }
 
     /**
      * Subscribe to Update Cart event
      */
     updateCart(handler: EventHandler): void {
-        this.addEventListener(UPDATE_CART, handler);
+        this.addEventListener(events.UPDATE_CART, handler);
     }
 }

--- a/src/SubscribeManager.ts
+++ b/src/SubscribeManager.ts
@@ -3,7 +3,7 @@
  * See COPYING.txt for license details.
  */
 
-import { Base } from "./base";
+import { Base } from "./Base";
 import events from "./events";
 import { ListenerOptions, EventHandler } from "./types/events";
 

--- a/src/UnsubscribeManager.ts
+++ b/src/UnsubscribeManager.ts
@@ -3,193 +3,169 @@
  * See COPYING.txt for license details.
  */
 
-import { Base } from "./Base";
-import {
-    ADD_TO_CART,
-    CUSTOM_URL,
-    DATA_LAYER_CHANGE,
-    DATA_LAYER_EVENT,
-    INITIATE_CHECKOUT,
-    EventHandler,
-    PAGE_ACTIVITY_SUMMARY,
-    PAGE_VIEW,
-    PLACE_ORDER,
-    PRODUCT_PAGE_VIEW,
-    RECS_ITEM_ADD_TO_CART_CLICK,
-    RECS_ITEM_CLICK,
-    RECS_REQUEST_SENT,
-    RECS_RESPONSE_RECEIVED,
-    RECS_UNIT_RENDER,
-    RECS_UNIT_VIEW,
-    REFERRER_URL,
-    REMOVE_FROM_CART,
-    SEARCH_REQUEST_SENT,
-    SEARCH_RESPONSE_RECEIVED,
-    SEARCH_RESULT_CLICK,
-    SIGN_IN,
-    SIGN_OUT,
-    UPDATE_CART,
-} from "./types/events";
+import { Base } from "./base";
+import events from "./events";
+import { EventHandler } from "./types/events";
 
 export default class UnsubscribeManager extends Base {
     /**
      *  Unsubscribe from Add to Cart event
      */
     addToCart(handler: EventHandler): void {
-        this.removeEventListener(ADD_TO_CART, handler);
+        this.removeEventListener(events.ADD_TO_CART, handler);
     }
 
     /**
      * Unsubscribe from Custom Url event
      */
     customUrl(handler: EventHandler): void {
-        this.removeEventListener(CUSTOM_URL, handler);
+        this.removeEventListener(events.CUSTOM_URL, handler);
     }
 
     /**
      * Unsubscribe from Data Layer Change event
      */
     dataLayerChange(handler: EventHandler): void {
-        this.removeEventListener(DATA_LAYER_CHANGE, handler);
+        this.removeEventListener(events.DATA_LAYER_CHANGE, handler);
     }
 
     /**
      * Unsubscribe from Data Layer Event event
      */
     dataLayerEvent(handler: EventHandler): void {
-        this.removeEventListener(DATA_LAYER_EVENT, handler);
+        this.removeEventListener(events.DATA_LAYER_EVENT, handler);
     }
 
     /**
      * Unsubscribe from Initiate Checkout event
      */
     initiateCheckout(handler: EventHandler): void {
-        this.removeEventListener(INITIATE_CHECKOUT, handler);
+        this.removeEventListener(events.INITIATE_CHECKOUT, handler);
     }
 
     /**
      * Unsubscribe from Page Activity Summary event
      */
     pageActivitySummary(handler: EventHandler): void {
-        this.removeEventListener(PAGE_ACTIVITY_SUMMARY, handler);
+        this.removeEventListener(events.PAGE_ACTIVITY_SUMMARY, handler);
     }
 
     /**
      * Unsubscribe from Page View event
      */
     pageView(handler: EventHandler): void {
-        this.removeEventListener(PAGE_VIEW, handler);
+        this.removeEventListener(events.PAGE_VIEW, handler);
     }
 
     /**
      * Unsubscribe from Place Order event
      */
     placeOrder(handler: EventHandler): void {
-        this.removeEventListener(PLACE_ORDER, handler);
+        this.removeEventListener(events.PLACE_ORDER, handler);
     }
 
     /**
      * Unsubscribe from Product Page View event
      */
     productPageView(handler: EventHandler): void {
-        this.removeEventListener(PRODUCT_PAGE_VIEW, handler);
+        this.removeEventListener(events.PRODUCT_PAGE_VIEW, handler);
     }
 
     /**
      * Unsubscribe to Recommended Item Add to Cart Click event
      */
     recsItemAddToCartClick(handler: EventHandler): void {
-        this.removeEventListener(RECS_ITEM_ADD_TO_CART_CLICK, handler);
+        this.removeEventListener(events.RECS_ITEM_ADD_TO_CART_CLICK, handler);
     }
 
     /**
      * Unsubscribe to Recommended Item Click event
      */
     recsItemClick(handler: EventHandler): void {
-        this.removeEventListener(RECS_ITEM_CLICK, handler);
+        this.removeEventListener(events.RECS_ITEM_CLICK, handler);
     }
 
     /**
      * Unsubscribe to Recommendations API Request event
      */
     recsRequestSent(handler: EventHandler): void {
-        this.removeEventListener(RECS_REQUEST_SENT, handler);
+        this.removeEventListener(events.RECS_REQUEST_SENT, handler);
     }
 
     /**
      * Unsubscribe to Recommendations Response Received event
      */
     recsResponseReceived(handler: EventHandler): void {
-        this.removeEventListener(RECS_RESPONSE_RECEIVED, handler);
+        this.removeEventListener(events.RECS_RESPONSE_RECEIVED, handler);
     }
 
     /**
      * Unsubscribe to Recommended Unit Render Event
      */
     recsUnitRender(handler: EventHandler): void {
-        this.removeEventListener(RECS_UNIT_RENDER, handler);
+        this.removeEventListener(events.RECS_UNIT_RENDER, handler);
     }
 
     /**
      * Unsubscribe to Recommended Unit View event
      */
     recsUnitView(handler: EventHandler): void {
-        this.removeEventListener(RECS_UNIT_VIEW, handler);
+        this.removeEventListener(events.RECS_UNIT_VIEW, handler);
     }
 
     /**
      * Unsubscribe from Referrer Url event
      */
     referrerUrl(handler: EventHandler): void {
-        this.removeEventListener(REFERRER_URL, handler);
+        this.removeEventListener(events.REFERRER_URL, handler);
     }
 
     /**
      * Unsubscribe from Remove from Cart event
      */
     removeFromCart(handler: EventHandler): void {
-        this.removeEventListener(REMOVE_FROM_CART, handler);
+        this.removeEventListener(events.REMOVE_FROM_CART, handler);
     }
 
     /**
      * Unsubscribe from Search Request Sent event
      */
     searchRequestSent(handler: EventHandler): void {
-        this.removeEventListener(SEARCH_REQUEST_SENT, handler);
+        this.removeEventListener(events.SEARCH_REQUEST_SENT, handler);
     }
 
     /**
      * Unsubscribe from Search Response Received event
      */
     searchResponseReceived(handler: EventHandler): void {
-        this.removeEventListener(SEARCH_RESPONSE_RECEIVED, handler);
+        this.removeEventListener(events.SEARCH_RESPONSE_RECEIVED, handler);
     }
 
     /**
      * Unsubscribe from Search Result Click event
      */
     searchResultClick(handler: EventHandler): void {
-        this.removeEventListener(SEARCH_RESULT_CLICK, handler);
+        this.removeEventListener(events.SEARCH_RESULT_CLICK, handler);
     }
 
     /**
      * Unsubscribe from Sign In event
      */
     signIn(handler: EventHandler): void {
-        this.removeEventListener(SIGN_IN, handler);
+        this.removeEventListener(events.SIGN_IN, handler);
     }
 
     /**
      * Unsubscribe from Sign Out event
      */
     signOut(handler: EventHandler): void {
-        this.removeEventListener(SIGN_OUT, handler);
+        this.removeEventListener(events.SIGN_OUT, handler);
     }
 
     /**
      * Unsubscribe from Update Cart event
      */
     updateCart(handler: EventHandler): void {
-        this.removeEventListener(UPDATE_CART, handler);
+        this.removeEventListener(events.UPDATE_CART, handler);
     }
 }

--- a/src/UnsubscribeManager.ts
+++ b/src/UnsubscribeManager.ts
@@ -3,7 +3,7 @@
  * See COPYING.txt for license details.
  */
 
-import { Base } from "./base";
+import { Base } from "./Base";
 import events from "./events";
 import { EventHandler } from "./types/events";
 

--- a/src/contexts.ts
+++ b/src/contexts.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+const contexts = {
+    CUSTOM_URL_CONTEXT: "customUrlContext",
+    MAGENTO_EXTENSION_CONTEXT: "magentoExtensionContext",
+    ORDER_CONTEXT: "orderContext",
+    PAGE_OFFSET_CONTEXT: "pageOffsetContext",
+    PRODUCT_CONTEXT: "productContext",
+    REFERRER_URL_CONTEXT: "referrerUrlContext",
+    SEARCH_INPUT_CONTEXT: "searchInputContext",
+    SEARCH_RESULTS_CONTEXT: "searchResultsContext",
+    SHOPPER_CONTEXT: "shopperContext",
+    SHOPPING_CART_CONTEXT: "shoppingCartContext",
+    STOREFRONT_INSTANCE_CONTEXT: "storefrontInstanceContext",
+};
+
+export default contexts;

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+const events = {
+    ADD_TO_CART: "add-to-cart",
+    CUSTOM_URL: "custom-url",
+    DATA_LAYER_CHANGE: "adobeDataLayer:change",
+    DATA_LAYER_EVENT: "adobeDataLayer:event",
+    INITIATE_CHECKOUT: "initiate-checkout",
+    PAGE_ACTIVITY_SUMMARY: "page-activity-summary",
+    PAGE_VIEW: "page-view",
+    PLACE_ORDER: "place-order",
+    PRODUCT_PAGE_VIEW: "product-page-view",
+    RECS_ITEM_CLICK: "recs-item-click",
+    RECS_ITEM_ADD_TO_CART_CLICK: "recs-item-add-to-cart-click",
+    RECS_REQUEST_SENT: "recs-api-request-sent",
+    RECS_RESPONSE_RECEIVED: "recs-api-response-received",
+    RECS_UNIT_RENDER: "recs-unit-impression-render",
+    RECS_UNIT_VIEW: "recs-unit-view",
+    REFERRER_URL: "referrer-url",
+    REMOVE_FROM_CART: "remove-from-cart",
+    SEARCH_REQUEST_SENT: "search-request-sent",
+    SEARCH_RESPONSE_RECEIVED: "search-response-received",
+    SEARCH_RESULT_CLICK: "search-result-click",
+    SIGN_IN: "sign-in",
+    SIGN_OUT: "sign-out",
+    UPDATE_CART: "update-cart",
+};
+
+export default events;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@
  * See COPYING.txt for license details.
  */
 
-import MagentoStorefrontEvents from "./magentoStorefrontEvents";
+import MagentoStorefrontEvents from "./MagentoStorefrontEvents";
 
 export { MagentoStorefrontEvents };
 export default new MagentoStorefrontEvents();

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,36 +3,7 @@
  * See COPYING.txt for license details.
  */
 
-import ContextManager from "./ContextManager";
-import PublishManager from "./PublishManager";
-import SubscribeManager from "./SubscribeManager";
-import UnsubscribeManager from "./UnsubscribeManager";
+import MagentoStorefrontEvents from "./magentoStorefrontEvents";
 
-export class MagentoStorefrontEvents {
-    constructor() {
-        // ensure event array is available
-        window.adobeDataLayer = window.adobeDataLayer || [];
-    }
-
-    /**
-     * Methods for interacting with context data
-     */
-    public context = new ContextManager();
-
-    /**
-     * Methods for publishing events
-     */
-    public publish = new PublishManager();
-
-    /**
-     * Methods for subscribing to events
-     */
-    public subscribe = new SubscribeManager();
-
-    /**
-     * Methods for unsubscribing from events
-     */
-    public unsubscribe = new UnsubscribeManager();
-}
-
+export { MagentoStorefrontEvents };
 export default new MagentoStorefrontEvents();

--- a/src/magentoStorefrontEvents.ts
+++ b/src/magentoStorefrontEvents.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+import ContextManager from "./contextManager";
+import PublishManager from "./publishManager";
+import SubscribeManager from "./subscribeManager";
+import UnsubscribeManager from "./unsubscribeManager";
+
+class MagentoStorefrontEvents {
+    constructor() {
+        // ensure event array is available
+        window.adobeDataLayer = window.adobeDataLayer || [];
+    }
+
+    /**
+     * Methods for interacting with context data
+     */
+    public context = new ContextManager();
+
+    /**
+     * Methods for publishing events
+     */
+    public publish = new PublishManager();
+
+    /**
+     * Methods for subscribing to events
+     */
+    public subscribe = new SubscribeManager();
+
+    /**
+     * Methods for unsubscribing from events
+     */
+    public unsubscribe = new UnsubscribeManager();
+}
+
+export default MagentoStorefrontEvents;

--- a/src/types/contexts.ts
+++ b/src/types/contexts.ts
@@ -3,30 +3,20 @@
  * See COPYING.txt for license details.
  */
 
-export const CUSTOM_URL_CONTEXT = "customUrlContext";
-export const MAGENTO_EXTENSION_CONTEXT = "magentoExtensionContext";
-export const ORDER_CONTEXT = "orderContext";
-export const PAGE_OFFSET_CONTEXT = "pageOffsetContext";
-export const PRODUCT_CONTEXT = "productContext";
-export const REFERRER_URL_CONTEXT = "referrerUrlContext";
-export const SEARCH_INPUT_CONTEXT = "searchInputContext";
-export const SEARCH_RESULTS_CONTEXT = "searchResultsContext";
-export const SHOPPER_CONTEXT = "shopperContext";
-export const SHOPPING_CART_CONTEXT = "shoppingCartContext";
-export const STOREFRONT_INSTANCE_CONTEXT = "storefrontInstanceContext";
+import contexts from "../contexts";
 
 export type ContextName =
-    | typeof CUSTOM_URL_CONTEXT
-    | typeof MAGENTO_EXTENSION_CONTEXT
-    | typeof ORDER_CONTEXT
-    | typeof PAGE_OFFSET_CONTEXT
-    | typeof PRODUCT_CONTEXT
-    | typeof REFERRER_URL_CONTEXT
-    | typeof SEARCH_INPUT_CONTEXT
-    | typeof SEARCH_RESULTS_CONTEXT
-    | typeof SHOPPER_CONTEXT
-    | typeof SHOPPING_CART_CONTEXT
-    | typeof STOREFRONT_INSTANCE_CONTEXT;
+    | typeof contexts.CUSTOM_URL_CONTEXT
+    | typeof contexts.MAGENTO_EXTENSION_CONTEXT
+    | typeof contexts.ORDER_CONTEXT
+    | typeof contexts.PAGE_OFFSET_CONTEXT
+    | typeof contexts.PRODUCT_CONTEXT
+    | typeof contexts.REFERRER_URL_CONTEXT
+    | typeof contexts.SEARCH_INPUT_CONTEXT
+    | typeof contexts.SEARCH_RESULTS_CONTEXT
+    | typeof contexts.SHOPPER_CONTEXT
+    | typeof contexts.SHOPPING_CART_CONTEXT
+    | typeof contexts.STOREFRONT_INSTANCE_CONTEXT;
 
 export type Context = {
     [K in ContextName]: unknown;

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -4,55 +4,32 @@
  */
 
 import { CustomContext, Context } from "./contexts";
-
-export const ADD_TO_CART = "add-to-cart";
-export const CUSTOM_URL = "custom-url";
-export const DATA_LAYER_CHANGE = "adobeDataLayer:change";
-export const DATA_LAYER_EVENT = "adobeDataLayer:event";
-export const INITIATE_CHECKOUT = "initiate-checkout";
-export const PAGE_ACTIVITY_SUMMARY = "page-activity-summary";
-export const PAGE_VIEW = "page-view";
-export const PLACE_ORDER = "place-order";
-export const PRODUCT_PAGE_VIEW = "product-page-view";
-export const RECS_ITEM_CLICK = "recs-item-click";
-export const RECS_ITEM_ADD_TO_CART_CLICK = "recs-item-add-to-cart-click";
-export const RECS_REQUEST_SENT = "recs-api-request-sent";
-export const RECS_RESPONSE_RECEIVED = "recs-api-response-received";
-export const RECS_UNIT_RENDER = "recs-unit-impression-render";
-export const RECS_UNIT_VIEW = "recs-unit-view";
-export const REFERRER_URL = "referrer-url";
-export const REMOVE_FROM_CART = "remove-from-cart";
-export const SEARCH_REQUEST_SENT = "search-request-sent";
-export const SEARCH_RESPONSE_RECEIVED = "search-response-received";
-export const SEARCH_RESULT_CLICK = "search-result-click";
-export const SIGN_IN = "sign-in";
-export const SIGN_OUT = "sign-out";
-export const UPDATE_CART = "update-cart";
+import events from "../events";
 
 export type EventName =
-    | typeof ADD_TO_CART
-    | typeof CUSTOM_URL
-    | typeof DATA_LAYER_CHANGE
-    | typeof DATA_LAYER_EVENT
-    | typeof INITIATE_CHECKOUT
-    | typeof PAGE_ACTIVITY_SUMMARY
-    | typeof PAGE_VIEW
-    | typeof PLACE_ORDER
-    | typeof PRODUCT_PAGE_VIEW
-    | typeof RECS_ITEM_CLICK
-    | typeof RECS_ITEM_ADD_TO_CART_CLICK
-    | typeof RECS_REQUEST_SENT
-    | typeof RECS_RESPONSE_RECEIVED
-    | typeof RECS_UNIT_RENDER
-    | typeof RECS_UNIT_VIEW
-    | typeof REFERRER_URL
-    | typeof REMOVE_FROM_CART
-    | typeof SEARCH_REQUEST_SENT
-    | typeof SEARCH_RESPONSE_RECEIVED
-    | typeof SEARCH_RESULT_CLICK
-    | typeof SIGN_IN
-    | typeof SIGN_OUT
-    | typeof UPDATE_CART;
+    | typeof events.ADD_TO_CART
+    | typeof events.CUSTOM_URL
+    | typeof events.DATA_LAYER_CHANGE
+    | typeof events.DATA_LAYER_EVENT
+    | typeof events.INITIATE_CHECKOUT
+    | typeof events.PAGE_ACTIVITY_SUMMARY
+    | typeof events.PAGE_VIEW
+    | typeof events.PLACE_ORDER
+    | typeof events.PRODUCT_PAGE_VIEW
+    | typeof events.RECS_ITEM_CLICK
+    | typeof events.RECS_ITEM_ADD_TO_CART_CLICK
+    | typeof events.RECS_REQUEST_SENT
+    | typeof events.RECS_RESPONSE_RECEIVED
+    | typeof events.RECS_UNIT_RENDER
+    | typeof events.RECS_UNIT_VIEW
+    | typeof events.REFERRER_URL
+    | typeof events.REMOVE_FROM_CART
+    | typeof events.SEARCH_REQUEST_SENT
+    | typeof events.SEARCH_RESPONSE_RECEIVED
+    | typeof events.SEARCH_RESULT_CLICK
+    | typeof events.SIGN_IN
+    | typeof events.SIGN_OUT
+    | typeof events.UPDATE_CART;
 
 export type Event = {
     event: EventName;

--- a/tests/events.test.ts
+++ b/tests/events.test.ts
@@ -2,31 +2,10 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+import contexts from "../src/contexts";
+import events from "../src/events";
 import mdl, { MagentoStorefrontEvents } from "../src/index";
-import {
-    CUSTOM_URL_CONTEXT,
-    REFERRER_URL_CONTEXT,
-} from "../src/types/contexts";
-import {
-    ADD_TO_CART,
-    CUSTOM_URL,
-    INITIATE_CHECKOUT,
-    Event,
-    PAGE_ACTIVITY_SUMMARY,
-    PAGE_VIEW,
-    PRODUCT_PAGE_VIEW,
-    RECS_ITEM_ADD_TO_CART_CLICK,
-    RECS_ITEM_CLICK,
-    RECS_REQUEST_SENT,
-    RECS_RESPONSE_RECEIVED,
-    RECS_UNIT_RENDER,
-    RECS_UNIT_VIEW,
-    REFERRER_URL,
-    REMOVE_FROM_CART,
-    SIGN_IN,
-    SIGN_OUT,
-    UPDATE_CART,
-} from "../src/types/events";
+import { Event } from "../src/types/events";
 import { Shopper } from "../src/types/schemas/shopper";
 
 beforeAll(() => {
@@ -49,7 +28,7 @@ describe("events", () => {
     test("add to cart", async () => {
         const eventHandler = jest.fn(eventObj => {
             expect(eventObj).toEqual({
-                event: ADD_TO_CART,
+                event: events.ADD_TO_CART,
                 eventInfo: expect.any(Object),
             });
         });
@@ -66,7 +45,7 @@ describe("events", () => {
     test("custom url", async () => {
         const eventHandler = jest.fn(eventObj => {
             expect(eventObj).toEqual({
-                event: CUSTOM_URL,
+                event: events.CUSTOM_URL,
                 eventInfo: expect.any(Object),
             });
         });
@@ -83,7 +62,7 @@ describe("events", () => {
     test("initiate checkout", async () => {
         const eventHandler = jest.fn(eventObj => {
             expect(eventObj).toEqual({
-                event: INITIATE_CHECKOUT,
+                event: events.INITIATE_CHECKOUT,
                 eventInfo: expect.any(Object),
             });
         });
@@ -100,7 +79,7 @@ describe("events", () => {
     test("page activity summary", async () => {
         const eventHandler = jest.fn(eventObj => {
             expect(eventObj).toEqual({
-                event: PAGE_ACTIVITY_SUMMARY,
+                event: events.PAGE_ACTIVITY_SUMMARY,
                 eventInfo: expect.any(Object),
             });
         });
@@ -117,7 +96,7 @@ describe("events", () => {
     test("page view", async () => {
         const eventHandler = jest.fn(eventObj => {
             expect(eventObj).toEqual({
-                event: PAGE_VIEW,
+                event: events.PAGE_VIEW,
                 eventInfo: expect.any(Object),
             });
         });
@@ -134,7 +113,7 @@ describe("events", () => {
     test("product page view", async () => {
         const eventHandler = jest.fn(eventObj => {
             expect(eventObj).toEqual({
-                event: PRODUCT_PAGE_VIEW,
+                event: events.PRODUCT_PAGE_VIEW,
                 eventInfo: expect.any(Object),
             });
         });
@@ -151,7 +130,7 @@ describe("events", () => {
     test("rec item add to cart click", () => {
         const eventHandler = jest.fn(eventObj => {
             expect(eventObj).toEqual({
-                event: RECS_ITEM_ADD_TO_CART_CLICK,
+                event: events.RECS_ITEM_ADD_TO_CART_CLICK,
                 eventInfo: expect.any(Object),
             });
         });
@@ -168,7 +147,7 @@ describe("events", () => {
     test("rec item click", () => {
         const eventHandler = jest.fn(eventObj => {
             expect(eventObj).toEqual({
-                event: RECS_ITEM_CLICK,
+                event: events.RECS_ITEM_CLICK,
                 eventInfo: expect.any(Object),
             });
         });
@@ -184,7 +163,7 @@ describe("events", () => {
     test("rec request sent", () => {
         const eventHandler = jest.fn(eventObj => {
             expect(eventObj).toEqual({
-                event: RECS_REQUEST_SENT,
+                event: events.RECS_REQUEST_SENT,
                 eventInfo: expect.any(Object),
             });
         });
@@ -201,7 +180,7 @@ describe("events", () => {
     test("rec response sent", () => {
         const eventHandler = jest.fn(eventObj => {
             expect(eventObj).toEqual({
-                event: RECS_RESPONSE_RECEIVED,
+                event: events.RECS_RESPONSE_RECEIVED,
                 eventInfo: expect.any(Object),
             });
         });
@@ -218,7 +197,7 @@ describe("events", () => {
     test("rec unit render", () => {
         const eventHandler = jest.fn(eventObj => {
             expect(eventObj).toEqual({
-                event: RECS_UNIT_RENDER,
+                event: events.RECS_UNIT_RENDER,
                 eventInfo: expect.any(Object),
             });
         });
@@ -235,7 +214,7 @@ describe("events", () => {
     test("rec unit view", () => {
         const eventHandler = jest.fn(eventObj => {
             expect(eventObj).toEqual({
-                event: RECS_UNIT_VIEW,
+                event: events.RECS_UNIT_VIEW,
                 eventInfo: expect.any(Object),
             });
         });
@@ -252,7 +231,7 @@ describe("events", () => {
     test("referrer url", async () => {
         const eventHandler = jest.fn(eventObj => {
             expect(eventObj).toEqual({
-                event: REFERRER_URL,
+                event: events.REFERRER_URL,
                 eventInfo: expect.any(Object),
             });
         });
@@ -269,7 +248,7 @@ describe("events", () => {
     test("remove from cart", async () => {
         const eventHandler = jest.fn(eventObj => {
             expect(eventObj).toEqual({
-                event: REMOVE_FROM_CART,
+                event: events.REMOVE_FROM_CART,
                 eventInfo: expect.any(Object),
             });
         });
@@ -286,7 +265,7 @@ describe("events", () => {
     test("sign in", async () => {
         const eventHandler = jest.fn(eventObj => {
             expect(eventObj).toEqual({
-                event: SIGN_IN,
+                event: events.SIGN_IN,
                 eventInfo: expect.any(Object),
             });
         });
@@ -303,7 +282,7 @@ describe("events", () => {
     test("sign out", async () => {
         const eventHandler = jest.fn(eventObj => {
             expect(eventObj).toEqual({
-                event: SIGN_OUT,
+                event: events.SIGN_OUT,
                 eventInfo: expect.any(Object),
             });
         });
@@ -320,7 +299,7 @@ describe("events", () => {
     test("update cart", async () => {
         const eventHandler = jest.fn(eventObj => {
             expect(eventObj).toEqual({
-                event: UPDATE_CART,
+                event: events.UPDATE_CART,
                 eventInfo: expect.any(Object),
             });
         });
@@ -385,15 +364,15 @@ describe("events", () => {
 
         const handler = (event: Event) => {
             expect(event.eventInfo).toEqual({
-                [CUSTOM_URL_CONTEXT]: expect.anything(),
-                [REFERRER_URL_CONTEXT]: myContext,
+                [contexts.CUSTOM_URL_CONTEXT]: expect.anything(),
+                [contexts.REFERRER_URL_CONTEXT]: myContext,
             });
         };
         // now set the context to something else
         mdl.context.setReferrerUrl({ referrerUrl: "different.me" });
         // fire event with context to overwrite
         mdl.subscribe.pageView(handler);
-        mdl.publish.pageView({ [REFERRER_URL_CONTEXT]: myContext });
+        mdl.publish.pageView({ [contexts.REFERRER_URL_CONTEXT]: myContext });
     });
 
     test("event context data is not persisted in data layer", () => {


### PR DESCRIPTION
## Description

Separate `events` and `contexts` from their related types.

## Related Issue

N/A

## Motivation and Context

Just a refactor. I was going to export the `events` and `contexts` strings but realized there was no need.

## How Has This Been Tested?

Tested locally in the `example` directory, as well as `jest` tests.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
