### PR TITLE
fix: fix storefront instance typo

### DIFF
--- a/src/types/schemas/storefrontInstance.ts
+++ b/src/types/schemas/storefrontInstance.ts
@@ -4,7 +4,7 @@
  */
 
 export type StorefrontInstance = {
-    environtmentId: string;
+    environmentId: string;
     instanceId?: string;
     environment: string;
     storeUrl: string;

--- a/tests/mocks.ts
+++ b/tests/mocks.ts
@@ -121,7 +121,7 @@ export const generateStorefrontInstanceContext = (
 ): StorefrontInstance => ({
     baseCurrencyCode: "USD",
     environment: "Test",
-    environtmentId: "12345",
+    environmentId: "12345",
     storeId: 12345,
     storeName: "Test Store",
     storeUrl: "https://www.test.org",


### PR DESCRIPTION
BREAKING CHANGE: Renamed environtmentId to environmentId.

## Description

Fixed a typo in the `StorefrontInstance` context.

## Related Issue

N/A

## Motivation and Context

Update the type definitions for the `StorefrontInstance` context, fixing a typo.

## How Has This Been Tested?

Ran `jest` tests.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
