### PR TITLE
fix: fix adjustment type definition

### DIFF
--- a/src/types/schemas/recommendations.ts
+++ b/src/types/schemas/recommendations.ts
@@ -59,5 +59,5 @@ export type Price = {
 
 export type Adjustment = {
     code: string;
-    value: number;
+    amount: number;
 };

--- a/tests/mocks.ts
+++ b/tests/mocks.ts
@@ -110,13 +110,23 @@ export const generateRecommendationsContext = (
                     url: "https://magento.com",
                     prices: {
                         maximum: {
-                            finalAdjustments: [],
+                            finalAdjustments: [
+                                {
+                                    code: "coupon",
+                                    amount: 10,
+                                },
+                            ],
                             final: 33.12,
                             regular: 33.12,
                             regularAdjustments: [],
                         },
                         minimum: {
-                            finalAdjustments: [],
+                            finalAdjustments: [
+                                {
+                                    code: "coupon",
+                                    amount: 10,
+                                },
+                            ],
                             final: 33.12,
                             regular: 33.12,
                             regularAdjustments: [],
@@ -151,13 +161,23 @@ export const generateRecommendationsContext = (
                     url: "https://magento.com",
                     prices: {
                         maximum: {
-                            finalAdjustments: [],
+                            finalAdjustments: [
+                                {
+                                    code: "coupon",
+                                    amount: 10,
+                                },
+                            ],
                             final: 12.22,
                             regular: 12.22,
                             regularAdjustments: [],
                         },
                         minimum: {
-                            finalAdjustments: [],
+                            finalAdjustments: [
+                                {
+                                    code: "coupon",
+                                    amount: 10,
+                                },
+                            ],
                             final: 12.22,
                             regular: 12.22,
                             regularAdjustments: [],


### PR DESCRIPTION
BREAKING CHANGE: Renamed adjustment.value to adjustment.amount.

## Description

Updated the type definition for `Adjustment` with the correct property name.

## Related Issue

N/A

## Motivation and Context

The type definition should align with the values received from the Magento GraphQL API.

## How Has This Been Tested?

Using our `jest` tests.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
