### PR TITLE
feat: add page context

### DIFF
--- a/src/ContextManager.ts
+++ b/src/ContextManager.ts
@@ -7,7 +7,7 @@ import { Base } from "./Base";
 import contexts from "./contexts";
 import {
     MagentoExtension,
-    PageOffset,
+    Page,
     Product,
     Shopper,
     StorefrontInstance,
@@ -85,15 +85,15 @@ export default class ContextManager extends Base {
     /**
      * Get page offset context
      */
-    getPageOffset(): PageOffset {
-        return this.getContext<PageOffset>(contexts.PAGE_OFFSET_CONTEXT);
+    getPage(): Page {
+        return this.getContext<Page>(contexts.PAGE_CONTEXT);
     }
 
     /**
      * Set page offset context
      */
-    setPageOffset(context: PageOffset): void {
-        this.setContext<PageOffset>(contexts.PAGE_OFFSET_CONTEXT, context);
+    setPage(context: Page): void {
+        this.setContext<Page>(contexts.PAGE_CONTEXT, context);
     }
 
     /**

--- a/src/contexts.ts
+++ b/src/contexts.ts
@@ -7,7 +7,7 @@ const contexts = {
     CUSTOM_URL_CONTEXT: "customUrlContext",
     MAGENTO_EXTENSION_CONTEXT: "magentoExtensionContext",
     ORDER_CONTEXT: "orderContext",
-    PAGE_OFFSET_CONTEXT: "pageOffsetContext",
+    PAGE_CONTEXT: "pageContext",
     PRODUCT_CONTEXT: "productContext",
     RECOMMENDATIONS_CONTEXT: "recommendationsContext",
     REFERRER_URL_CONTEXT: "referrerUrlContext",

--- a/src/types/contexts.ts
+++ b/src/types/contexts.ts
@@ -9,7 +9,7 @@ export type ContextName =
     | typeof contexts.CUSTOM_URL_CONTEXT
     | typeof contexts.MAGENTO_EXTENSION_CONTEXT
     | typeof contexts.ORDER_CONTEXT
-    | typeof contexts.PAGE_OFFSET_CONTEXT
+    | typeof contexts.PAGE_CONTEXT
     | typeof contexts.PRODUCT_CONTEXT
     | typeof contexts.REFERRER_URL_CONTEXT
     | typeof contexts.SEARCH_INPUT_CONTEXT

--- a/src/types/schemas/index.ts
+++ b/src/types/schemas/index.ts
@@ -5,7 +5,7 @@ export * from "./giftCard";
 export * from "./magentoExtension";
 export * from "./magentoJsTracker";
 export * from "./order";
-export * from "./pageOffset";
+export * from "./page";
 export * from "./product";
 export * from "./recommendations";
 export * from "./referrerUrl";

--- a/src/types/schemas/page.ts
+++ b/src/types/schemas/page.ts
@@ -3,7 +3,8 @@
  * See COPYING.txt for license details.
  */
 
-export type PageOffset = {
+export type Page = {
+    pageType: string;
     eventType?: "pageUnload" | "visibilityHidden";
     maxXOffset: number;
     maxYOffset: number;

--- a/tests/contexts.test.ts
+++ b/tests/contexts.test.ts
@@ -8,7 +8,7 @@ import {
     generateCustomUrlContext,
     generateMagentoExtensionContext,
     generateOrderContext,
-    generatePageOffsetsContext,
+    generatePageContext,
     generateProductContext,
     generateRecommendationsContext,
     generateReferrerUrlContext,
@@ -57,11 +57,11 @@ describe("contexts", () => {
         expect(mdl.context.getOrder()).toEqual(context);
     });
 
-    test("page offset context", () => {
-        const context = generatePageOffsetsContext();
-        expect(mdl.context.getPageOffset()).toBeUndefined();
-        mdl.context.setPageOffset(context);
-        expect(mdl.context.getPageOffset()).toEqual(context);
+    test("page context", () => {
+        const context = generatePageContext();
+        expect(mdl.context.getPage()).toBeUndefined();
+        mdl.context.setPage(context);
+        expect(mdl.context.getPage()).toEqual(context);
     });
 
     test("product context", () => {

--- a/tests/mocks.ts
+++ b/tests/mocks.ts
@@ -7,7 +7,7 @@ import { CustomUrl } from "../src/types/schemas/customUrl";
 import {
     MagentoExtension,
     Order,
-    PageOffset,
+    Page,
     Product,
     Recommendations,
     ReferrerUrl,
@@ -46,9 +46,8 @@ export const generateOrderContext = (overrides?: Partial<Order>): Order => ({
     ...overrides,
 });
 
-export const generatePageOffsetsContext = (
-    overrides?: Partial<PageOffset>,
-): PageOffset => ({
+export const generatePageContext = (overrides?: Partial<Page>): Page => ({
+    pageType: "pdp",
     eventType: "visibilityHidden",
     maxXOffset: 0,
     maxYOffset: 0,


### PR DESCRIPTION
Modified the PageOffset context to include a pageType property, and renamed it to Page.

BREAKING CHANGE: Renamed the getPageOffset and setPageOffset methods to getPage and setPage.

SEARCH-1329

## Description

Added a `Page` context with a `pageType` property.

## Related Issue

[SEARCH-1329](https://jira.corp.magento.com/browse/SEARCH-1329)

## Motivation and Context

Need to send the `pageType` with every event. Previously, this was not tracked in context, so we need a place for it.

## How Has This Been Tested?

Tested with `jest` tests and locally using the `example` directory.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
