### PR TITLE
feat: pass additional data to publish

### DIFF
--- a/example/context.js
+++ b/example/context.js
@@ -1,0 +1,285 @@
+const mse = window.magentoStorefrontEvents;
+
+mse.context.setPage({
+    pageType: "pdp",
+    maxXOffset: 0,
+    maxYOffset: 0,
+    minXOffset: 0,
+    minYOffset: 0,
+    ping_interval: 5,
+    pings: 12,
+});
+
+mse.context.setRecommendations({
+    units: [
+        {
+            unitId: "abc123",
+            unitName: "most-viewed",
+            unitType: "primary",
+            searchTime: 2,
+            totalProducts: 2,
+            primaryProducts: 2,
+            backupProducts: 0,
+            products: [
+                {
+                    rank: 1,
+                    score: 100.5,
+                    sku: "space sku tst two",
+                    name: "space sku tst two",
+                    productId: 2051,
+                    shortDescription: "short product description",
+                    type: "simple",
+                    visibility: "Catalog, Search",
+                    categories: [
+                        "",
+                        "gear",
+                        "collections",
+                        "training",
+                        "men",
+                        "women",
+                        "promotions",
+                        "gift-cards",
+                        "sale",
+                        "what-is-new",
+                        "what-is-new/qa",
+                    ],
+                    weight: 7.0,
+                    currency: "USD",
+                    url: "https://magento.com",
+                    prices: {
+                        maximum: {
+                            finalAdjustments: [
+                                {
+                                    code: "coupon",
+                                    amount: 10,
+                                },
+                            ],
+                            final: 33.12,
+                            regular: 33.12,
+                            regularAdjustments: [],
+                        },
+                        minimum: {
+                            finalAdjustments: [
+                                {
+                                    code: "coupon",
+                                    amount: 10,
+                                },
+                            ],
+                            final: 33.12,
+                            regular: 33.12,
+                            regularAdjustments: [],
+                        },
+                    },
+                    queryType: "primary",
+                },
+                {
+                    rank: 2,
+                    score: 100.5,
+                    sku: "space sku tst three",
+                    name: "space sku tst three",
+                    productId: 2052,
+                    shortDescription: "short product description",
+                    type: "simple",
+                    visibility: "Catalog, Search",
+                    categories: [
+                        "",
+                        "gear",
+                        "collections",
+                        "training",
+                        "men",
+                        "women",
+                        "promotions",
+                        "gift-cards",
+                        "sale",
+                        "what-is-new",
+                        "what-is-new/qa",
+                    ],
+                    weight: 7.0,
+                    currency: "USD",
+                    url: "https://magento.com",
+                    prices: {
+                        maximum: {
+                            finalAdjustments: [
+                                {
+                                    code: "coupon",
+                                    amount: 10,
+                                },
+                            ],
+                            final: 12.22,
+                            regular: 12.22,
+                            regularAdjustments: [],
+                        },
+                        minimum: {
+                            finalAdjustments: [
+                                {
+                                    code: "coupon",
+                                    amount: 10,
+                                },
+                            ],
+                            final: 12.22,
+                            regular: 12.22,
+                            regularAdjustments: [],
+                        },
+                    },
+                    queryType: "primary",
+                },
+            ],
+        },
+    ],
+});
+
+mse.context.setProduct({
+    productId: 111111,
+    name: "T-Shirt",
+    sku: "aaaaaa",
+    topLevelSku: "bbbbbb",
+    specialToDate: "01/10/2021",
+    specialFromDate: "01/01/2021",
+    newToDate: "01/10/2021",
+    newFromDate: "01/01/2021",
+    createdAt: "01/01/2021",
+    updatedAt: "01/01/2021",
+    manufacturer: "Magento",
+    countryOfManufacture: "USA",
+    categories: ["Tops", "Shirts"],
+    productType: "normal",
+    pricing: {
+        regularPrice: 19.99,
+        minimalPrice: 10.99,
+        maximalPrice: 24.99,
+        specialPrice: 14.99,
+        tierPricing: [],
+        currencyCode: "USD",
+    },
+    canonicalUrl: "https://magento.com/tshirt",
+    mainImageUrl: "https://magento.com/tshirt.jpg",
+});
+
+mse.context.setOrder({
+    appliedCouponCode: "",
+    email: "example@email.com",
+    grandTotal: 69.98,
+    orderId: 111111,
+    otherTax: 0.0,
+    paymentMethodCode: "credit card",
+    paymentMethodName: "visa",
+    salesTax: 0.0,
+    subtotalExcludingTax: 69.98,
+    subtotalIncludingTax: 69.98,
+});
+
+mse.context.setShoppingCart({
+    id: "111111",
+    items: [
+        {
+            canApplyMsrp: false,
+            formattedPrice: "$19.99",
+            id: "aaaaaa",
+            prices: [{ value: 19.99, currency: "USD" }],
+            product: {
+                productId: "bbbbbb",
+                name: "T-Shirt",
+                sku: "ts001",
+            },
+            configurableOptions: [],
+            quantity: 1,
+        },
+        {
+            canApplyMsrp: false,
+            formattedPrice: "$49.99",
+            id: "cccccc",
+            prices: [{ value: 49.99, currency: "USD" }],
+            product: {
+                productId: "dddddd",
+                name: "Hoodie",
+                sku: "h001",
+            },
+            configurableOptions: [],
+            quantity: 1,
+        },
+    ],
+    prices: [
+        {
+            value: 19.99,
+            currency: "USD",
+        },
+        {
+            value: 49.99,
+            currency: "USD",
+        },
+    ],
+    totalQuantity: 2,
+});
+
+mse.context.setMagentoExtension({
+    magentoExtensionVersion: "1.2.3",
+});
+
+mse.context.setStorefrontInstance({
+    baseCurrencyCode: "USD",
+    storeViewCurrencyCode: "USD",
+    environment: "production",
+    environmentId: "aaaaaa",
+    instanceId: "bbbbbb",
+    storeCode: "magento",
+    storeId: 111111,
+    storeName: "magento",
+    storeUrl: "https://magento.com",
+    storeViewCode: "default",
+    storeViewId: 222222,
+    storeViewName: "default",
+    websiteCode: "website",
+    websiteId: 333333,
+    websiteName: "website",
+});
+
+mse.context.setShopper({
+    shopperId: "logged-in",
+});
+
+mse.context.setSearchInput({
+    source: "search-bar",
+    query: "red patns",
+    page: 1,
+    perPage: 20,
+    refinementAttribute: null,
+    refinementSelection: null,
+    sortType: "relevance",
+    sortOrder: "descending",
+});
+
+mse.context.setSearchResults({
+    products: [
+        {
+            name: "Red Pants",
+            sku: "abc123",
+            url: "https://magento.com/red-pants",
+            imageUrl: "https://magento.com/red-pants.jpg",
+            price: 49.99,
+            rank: 1,
+        },
+    ],
+    suggestions: [
+        {
+            suggestion: "red pants",
+            rank: 1,
+        },
+    ],
+    categories: [
+        {
+            name: "Pants",
+            url: "https://magento.com/category/pants",
+            rank: 1,
+        },
+        {
+            name: "Bottoms",
+            url: "https://magento.com/category/bottoms",
+            rank: 2,
+        },
+    ],
+    page: 1,
+    perPage: 20,
+    productCount: 1,
+    categoryCount: 2,
+    suggestionCount: 1,
+});

--- a/example/index.html
+++ b/example/index.html
@@ -2,16 +2,9 @@
     <head>
         <script src="https://unpkg.com/@adobe/adobe-client-data-layer@2.0.1/dist/adobe-client-data-layer.min.js"></script>
         <script src="http://localhost:8080/index.js"></script>
-
-        <script>
-            const mdl = window.magentoStorefrontEvents;
-
-            mdl.subscribe.addToCart(() => console.log("addToCart"));
-
-            setTimeout(() => {
-                mdl.publish.addToCart();
-            }, 1000);
-        </script>
+        <script src="/context.js"></script>
+        <script src="/subscribe.js"></script>
+        <script src="/publish.js"></script>
     </head>
 
     <body>

--- a/example/publish.js
+++ b/example/publish.js
@@ -1,0 +1,29 @@
+const mse = window.magentoStorefrontEvents;
+
+setTimeout(() => {
+    mse.publish.addToCart();
+    mse.publish.customUrl();
+    mse.publish.initiateCheckout();
+    mse.publish.pageActivitySummary();
+    mse.publish.pageView();
+    mse.publish.placeOrder();
+    mse.publish.productPageView();
+    mse.publish.recsItemAddToCartClick("abc123", 123456);
+    mse.publish.recsItemClick("abc123", 123456);
+    mse.publish.recsRequestSent();
+    mse.publish.recsResponseReceived();
+    mse.publish.recsUnitRender("abc123");
+    mse.publish.recsUnitView("abc123");
+    mse.publish.referrerUrl();
+    mse.publish.removeFromCart();
+    mse.publish.searchCategoryClick("tops");
+    mse.publish.searchProductClick("abc123");
+    mse.publish.searchRequestSent();
+    mse.publish.searchResponseReceived();
+    mse.publish.searchResultsView();
+    mse.publish.searchSuggestionClick("pants");
+    mse.publish.shoppingCartView();
+    mse.publish.signIn();
+    mse.publish.signOut();
+    mse.publish.updateCart();
+}, 1000);

--- a/example/subscribe.js
+++ b/example/subscribe.js
@@ -1,0 +1,28 @@
+/* eslint-disable no-console */
+const mse = window.magentoStorefrontEvents;
+
+mse.subscribe.addToCart(args => console.log(args));
+mse.subscribe.customUrl(args => console.log(args));
+mse.subscribe.initiateCheckout(args => console.log(args));
+mse.subscribe.pageActivitySummary(args => console.log(args));
+mse.subscribe.pageView(args => console.log(args));
+mse.subscribe.placeOrder(args => console.log(args));
+mse.subscribe.productPageView(args => console.log(args));
+mse.subscribe.recsItemAddToCartClick(args => console.log(args));
+mse.subscribe.recsItemClick(args => console.log(args));
+mse.subscribe.recsRequestSent(args => console.log(args));
+mse.subscribe.recsResponseReceived(args => console.log(args));
+mse.subscribe.recsUnitRender(args => console.log(args));
+mse.subscribe.recsUnitView(args => console.log(args));
+mse.subscribe.referrerUrl(args => console.log(args));
+mse.subscribe.removeFromCart(args => console.log(args));
+mse.subscribe.searchCategoryClick(args => console.log(args));
+mse.subscribe.searchProductClick(args => console.log(args));
+mse.subscribe.searchRequestSent(args => console.log(args));
+mse.subscribe.searchResponseReceived(args => console.log(args));
+mse.subscribe.searchResultsView(args => console.log(args));
+mse.subscribe.searchSuggestionClick(args => console.log(args));
+mse.subscribe.shoppingCartView(args => console.log(args));
+mse.subscribe.signIn(args => console.log(args));
+mse.subscribe.signOut(args => console.log(args));
+mse.subscribe.updateCart(args => console.log(args));

--- a/src/Base.ts
+++ b/src/Base.ts
@@ -16,35 +16,39 @@ export abstract class Base {
             [name]: context,
         });
     }
+
     // Get a context from ACDL
     protected getContext<T>(name?: ContextName): T {
         return window.adobeDataLayer.getState
             ? window.adobeDataLayer.getState(name)
             : ({} as T);
     }
+
     // Add event listener to ACDL
     protected addEventListener(
         name: EventName,
         handler: EventHandler,
         options?: ListenerOptions,
     ): void {
-        window.adobeDataLayer.push((dl: AdobeClientDataLayer) => {
-            dl.addEventListener(name, handler, options);
+        window.adobeDataLayer.push((acdl: AdobeClientDataLayer) => {
+            acdl.addEventListener(name, handler, options);
         });
     }
+
     // Remove event listener from ACDL
     protected removeEventListener(
         name: EventName,
         handler: EventHandler,
     ): void {
-        window.adobeDataLayer.push((dl: AdobeClientDataLayer) => {
-            dl.removeEventListener(name, handler);
+        window.adobeDataLayer.push((acdl: AdobeClientDataLayer) => {
+            acdl.removeEventListener(name, handler);
         });
     }
+
     // Push event to ACDL
     protected pushEvent(event: EventName, context: CustomContext = {}): void {
-        window.adobeDataLayer.push((dl: AdobeClientDataLayer) => {
-            dl.push({
+        window.adobeDataLayer.push((acdl: AdobeClientDataLayer) => {
+            acdl.push({
                 event,
                 eventInfo: {
                     ...this.getContext<Context>(),

--- a/src/PublishManager.ts
+++ b/src/PublishManager.ts
@@ -6,180 +6,239 @@
 import { Base } from "./Base";
 import events from "./events";
 import { CustomContext } from "./types/contexts";
+import {
+    RecommendationUnit,
+    RecommendedProduct,
+    SearchResultCategory,
+    SearchResultProduct,
+    SearchResultSuggestion,
+} from "./types/schemas";
 
 export default class PublishManager extends Base {
     /**
      * Publish Add to Cart event
      */
     addToCart(context?: CustomContext): void {
-        this.pushEvent(events.ADD_TO_CART, context);
+        this.pushEvent(events.ADD_TO_CART, { customContext: context });
     }
 
     /**
      * Publish Custom Url event
      */
     customUrl(context?: CustomContext): void {
-        this.pushEvent(events.CUSTOM_URL, context);
+        this.pushEvent(events.CUSTOM_URL, { customContext: context });
     }
 
     /**
      * Publish Initiate Checkout event
      */
     initiateCheckout(context?: CustomContext): void {
-        this.pushEvent(events.INITIATE_CHECKOUT, context);
+        this.pushEvent(events.INITIATE_CHECKOUT, { customContext: context });
     }
 
     /**
      * Publish Page Activity Summary event
      */
     pageActivitySummary(context?: CustomContext): void {
-        this.pushEvent(events.PAGE_ACTIVITY_SUMMARY, context);
+        this.pushEvent(events.PAGE_ACTIVITY_SUMMARY, {
+            customContext: context,
+        });
     }
 
     /**
      * Publish Page View event
      */
     pageView(context?: CustomContext): void {
-        this.pushEvent(events.PAGE_VIEW, context);
+        this.pushEvent(events.PAGE_VIEW, { customContext: context });
     }
 
     /**
      * Publish Place Order event
      */
     placeOrder(context?: CustomContext): void {
-        this.pushEvent(events.PLACE_ORDER, context);
+        this.pushEvent(events.PLACE_ORDER, { customContext: context });
     }
 
     /**
      * Publish Product Page View event
      */
     productPageView(context?: CustomContext): void {
-        this.pushEvent(events.PRODUCT_PAGE_VIEW, context);
+        this.pushEvent(events.PRODUCT_PAGE_VIEW, { customContext: context });
     }
 
     /**
      * Publish Recommended Item Add to Cart Click event
      */
-    recsItemAddToCartClick(context?: CustomContext): void {
-        this.pushEvent(events.RECS_ITEM_ADD_TO_CART_CLICK, context);
+    recsItemAddToCartClick(
+        unitId: RecommendationUnit["unitId"],
+        productId: RecommendedProduct["productId"],
+        context?: CustomContext,
+    ): void {
+        this.pushEvent(events.RECS_ITEM_ADD_TO_CART_CLICK, {
+            unitId,
+            productId,
+            customContext: context,
+        });
     }
 
     /**
      * Publish Recommended Item Click event
      */
-    recsItemClick(context?: CustomContext): void {
-        this.pushEvent(events.RECS_ITEM_CLICK, context);
+    recsItemClick(
+        unitId: RecommendationUnit["unitId"],
+        productId: RecommendedProduct["productId"],
+        context?: CustomContext,
+    ): void {
+        this.pushEvent(events.RECS_ITEM_CLICK, {
+            unitId,
+            productId,
+            customContext: context,
+        });
     }
 
     /**
      * Publish Recommendations API Request event
      */
     recsRequestSent(context?: CustomContext): void {
-        this.pushEvent(events.RECS_REQUEST_SENT, context);
+        this.pushEvent(events.RECS_REQUEST_SENT, { customContext: context });
     }
 
     /**
      * Publish Recommendations Response Received event
      */
     recsResponseReceived(context?: CustomContext): void {
-        this.pushEvent(events.RECS_RESPONSE_RECEIVED, context);
+        this.pushEvent(events.RECS_RESPONSE_RECEIVED, {
+            customContext: context,
+        });
     }
 
     /**
      * Publish Recommended Unit Render Event
      */
-    recsUnitRender(context?: CustomContext): void {
-        this.pushEvent(events.RECS_UNIT_RENDER, context);
+    recsUnitRender(
+        unitId: RecommendationUnit["unitId"],
+        context?: CustomContext,
+    ): void {
+        this.pushEvent(events.RECS_UNIT_RENDER, {
+            unitId,
+            customContext: context,
+        });
     }
 
     /**
      * Publish Recommended Unit View event
      */
-    recsUnitView(context?: CustomContext): void {
-        this.pushEvent(events.RECS_UNIT_VIEW, context);
+    recsUnitView(
+        unitId: RecommendationUnit["unitId"],
+        context?: CustomContext,
+    ): void {
+        this.pushEvent(events.RECS_UNIT_VIEW, {
+            unitId,
+            customContext: context,
+        });
     }
 
     /**
      * Publish Referrer Url event
      */
     referrerUrl(context?: CustomContext): void {
-        this.pushEvent(events.REFERRER_URL, context);
+        this.pushEvent(events.REFERRER_URL, { customContext: context });
     }
 
     /**
      * Publish Remove from Cart event
      */
     removeFromCart(context?: CustomContext): void {
-        this.pushEvent(events.REMOVE_FROM_CART, context);
+        this.pushEvent(events.REMOVE_FROM_CART, { customContext: context });
     }
 
     /**
      * Publish Search Category Click event
      */
-    searchCategoryClick(context?: CustomContext): void {
-        this.pushEvent(events.SEARCH_CATEGORY_CLICK, context);
+    searchCategoryClick(
+        name: SearchResultCategory["name"],
+        context?: CustomContext,
+    ): void {
+        this.pushEvent(events.SEARCH_CATEGORY_CLICK, {
+            name,
+            customContext: context,
+        });
     }
 
     /**
      * Publish Search Product Click event
      */
-    searchProductClick(context?: CustomContext): void {
-        this.pushEvent(events.SEARCH_PRODUCT_CLICK, context);
+    searchProductClick(
+        sku: SearchResultProduct["sku"],
+        context?: CustomContext,
+    ): void {
+        this.pushEvent(events.SEARCH_PRODUCT_CLICK, {
+            sku,
+            customContext: context,
+        });
     }
 
     /**
      * Publish Search Request Sent event
      */
     searchRequestSent(context?: CustomContext): void {
-        this.pushEvent(events.SEARCH_REQUEST_SENT, context);
+        this.pushEvent(events.SEARCH_REQUEST_SENT, { customContext: context });
     }
 
     /**
      * Publish Search Response Received event
      */
     searchResponseReceived(context?: CustomContext): void {
-        this.pushEvent(events.SEARCH_RESPONSE_RECEIVED, context);
+        this.pushEvent(events.SEARCH_RESPONSE_RECEIVED, {
+            customContext: context,
+        });
     }
 
     /**
      * Publish Search Results View event
      */
     searchResultsView(context?: CustomContext): void {
-        this.pushEvent(events.SEARCH_RESULTS_VIEW, context);
+        this.pushEvent(events.SEARCH_RESULTS_VIEW, { customContext: context });
     }
 
     /**
      * Publish Search Suggestion Click event
      */
-    searchSuggestionClick(context?: CustomContext): void {
-        this.pushEvent(events.SEARCH_SUGGESTION_CLICK, context);
+    searchSuggestionClick(
+        suggestion: SearchResultSuggestion["suggestion"],
+        context?: CustomContext,
+    ): void {
+        this.pushEvent(events.SEARCH_SUGGESTION_CLICK, {
+            suggestion,
+            customContext: context,
+        });
     }
 
     /**
      * Publish Shopping Cart View event
      */
     shoppingCartView(context?: CustomContext): void {
-        this.pushEvent(events.SHOPPING_CART_VIEW, context);
+        this.pushEvent(events.SHOPPING_CART_VIEW, { customContext: context });
     }
 
     /**
      * Publish Sign In event
      */
     signIn(context?: CustomContext): void {
-        this.pushEvent(events.SIGN_IN, context);
+        this.pushEvent(events.SIGN_IN, { customContext: context });
     }
 
     /**
      * Publish Sign Out event
      */
     signOut(context?: CustomContext): void {
-        this.pushEvent(events.SIGN_OUT, context);
+        this.pushEvent(events.SIGN_OUT, { customContext: context });
     }
 
     /**
      * Publish Cart Update events
      */
     updateCart(context?: CustomContext): void {
-        this.pushEvent(events.UPDATE_CART, context);
+        this.pushEvent(events.UPDATE_CART, { customContext: context });
     }
 }

--- a/src/types/schemas/searchResults.ts
+++ b/src/types/schemas/searchResults.ts
@@ -3,7 +3,7 @@
  * See COPYING.txt for license details.
  */
 
-type SearchResultProduct = {
+export type SearchResultProduct = {
     name: string;
     sku: string;
     url: string;
@@ -12,13 +12,13 @@ type SearchResultProduct = {
     rank: number;
 };
 
-type SearchResultCategory = {
+export type SearchResultCategory = {
     name: string;
     url: string;
     rank: number;
 };
 
-type SearchResultSuggestion = {
+export type SearchResultSuggestion = {
     suggestion: string;
     rank: number;
 };

--- a/tests/events.test.ts
+++ b/tests/events.test.ts
@@ -110,6 +110,23 @@ describe("events", () => {
         expect(eventHandler).toHaveBeenCalledTimes(1);
     });
 
+    test("place order", async () => {
+        const eventHandler = jest.fn(eventObj => {
+            expect(eventObj).toEqual({
+                event: events.PLACE_ORDER,
+                eventInfo: expect.any(Object),
+            });
+        });
+
+        mdl.subscribe.placeOrder(eventHandler);
+        expect(eventHandler).not.toHaveBeenCalled();
+        mdl.publish.placeOrder();
+        expect(eventHandler).toHaveBeenCalledTimes(1);
+        mdl.unsubscribe.placeOrder(eventHandler);
+        mdl.publish.placeOrder();
+        expect(eventHandler).toHaveBeenCalledTimes(1);
+    });
+
     test("product page view", async () => {
         const eventHandler = jest.fn(eventObj => {
             expect(eventObj).toEqual({
@@ -137,10 +154,10 @@ describe("events", () => {
 
         mdl.subscribe.recsItemAddToCartClick(eventHandler);
         expect(eventHandler).not.toHaveBeenCalled();
-        mdl.publish.recsItemAddToCartClick();
+        mdl.publish.recsItemAddToCartClick("abc123", 123456);
         expect(eventHandler).toHaveBeenCalledTimes(1);
         mdl.unsubscribe.recsItemAddToCartClick(eventHandler);
-        mdl.publish.recsItemAddToCartClick();
+        mdl.publish.recsItemAddToCartClick("abc123", 123456);
         expect(eventHandler).toHaveBeenCalledTimes(1);
     });
 
@@ -153,10 +170,10 @@ describe("events", () => {
         });
         mdl.subscribe.recsItemClick(eventHandler);
         expect(eventHandler).not.toHaveBeenCalled();
-        mdl.publish.recsItemClick();
+        mdl.publish.recsItemClick("abc123", 123456);
         expect(eventHandler).toHaveBeenCalledTimes(1);
         mdl.unsubscribe.recsItemClick(eventHandler);
-        mdl.publish.recsItemClick();
+        mdl.publish.recsItemClick("abc123", 123456);
         expect(eventHandler).toHaveBeenCalledTimes(1);
     });
 
@@ -204,10 +221,10 @@ describe("events", () => {
 
         mdl.subscribe.recsUnitRender(eventHandler);
         expect(eventHandler).not.toHaveBeenCalled();
-        mdl.publish.recsUnitRender();
+        mdl.publish.recsUnitRender("abc123");
         expect(eventHandler).toHaveBeenCalledTimes(1);
         mdl.unsubscribe.recsUnitRender(eventHandler);
-        mdl.publish.recsUnitRender();
+        mdl.publish.recsUnitRender("abc123");
         expect(eventHandler).toHaveBeenCalledTimes(1);
     });
 
@@ -221,10 +238,10 @@ describe("events", () => {
 
         mdl.subscribe.recsUnitView(eventHandler);
         expect(eventHandler).not.toHaveBeenCalled();
-        mdl.publish.recsUnitView();
+        mdl.publish.recsUnitView("abc123");
         expect(eventHandler).toHaveBeenCalledTimes(1);
         mdl.unsubscribe.recsUnitView(eventHandler);
-        mdl.publish.recsUnitView();
+        mdl.publish.recsUnitView("abc123");
         expect(eventHandler).toHaveBeenCalledTimes(1);
     });
 
@@ -272,10 +289,10 @@ describe("events", () => {
 
         mdl.subscribe.searchCategoryClick(eventHandler);
         expect(eventHandler).not.toHaveBeenCalled();
-        mdl.publish.searchCategoryClick();
+        mdl.publish.searchCategoryClick("tops");
         expect(eventHandler).toHaveBeenCalledTimes(1);
         mdl.unsubscribe.searchCategoryClick(eventHandler);
-        mdl.publish.searchCategoryClick();
+        mdl.publish.searchCategoryClick("tops");
         expect(eventHandler).toHaveBeenCalledTimes(1);
     });
 
@@ -289,10 +306,10 @@ describe("events", () => {
 
         mdl.subscribe.searchProductClick(eventHandler);
         expect(eventHandler).not.toHaveBeenCalled();
-        mdl.publish.searchProductClick();
+        mdl.publish.searchProductClick("abc123");
         expect(eventHandler).toHaveBeenCalledTimes(1);
         mdl.unsubscribe.searchProductClick(eventHandler);
-        mdl.publish.searchProductClick();
+        mdl.publish.searchProductClick("abc123");
         expect(eventHandler).toHaveBeenCalledTimes(1);
     });
 
@@ -357,10 +374,10 @@ describe("events", () => {
 
         mdl.subscribe.searchSuggestionClick(eventHandler);
         expect(eventHandler).not.toHaveBeenCalled();
-        mdl.publish.searchSuggestionClick();
+        mdl.publish.searchSuggestionClick("pants");
         expect(eventHandler).toHaveBeenCalledTimes(1);
         mdl.unsubscribe.searchSuggestionClick(eventHandler);
-        mdl.publish.searchSuggestionClick();
+        mdl.publish.searchSuggestionClick("pants");
         expect(eventHandler).toHaveBeenCalledTimes(1);
     });
 
@@ -466,32 +483,15 @@ describe("events", () => {
         mdl.subscribe.signIn(deferredHandler);
     });
 
-    test("event publisher passes user-defined context through to subscribers", () => {
-        const myContext = { foo: "bar" };
+    test("event publisher passes custom context through to subscribers", () => {
+        const customContext = { foo: "bar" };
+
         const handler = (event: Event) => {
-            expect(event.eventInfo).toEqual(myContext);
+            expect(event.eventInfo).toEqual({ customContext });
         };
 
         mdl.subscribe.addToCart(handler);
-        mdl.publish.addToCart(myContext);
-    });
-
-    test("user-defined context merges with and overrides acdl context", () => {
-        mdl.context.setCustomUrl({ customUrl: "testing.edu" });
-        mdl.context.setReferrerUrl({ referrerUrl: "test.com" });
-        const myContext = mdl.context.getReferrerUrl(); // using get/set to make sure our context matches exactly what referrer context would look like in the data layer
-
-        const handler = (event: Event) => {
-            expect(event.eventInfo).toEqual({
-                [contexts.CUSTOM_URL_CONTEXT]: expect.anything(),
-                [contexts.REFERRER_URL_CONTEXT]: myContext,
-            });
-        };
-        // now set the context to something else
-        mdl.context.setReferrerUrl({ referrerUrl: "different.me" });
-        // fire event with context to overwrite
-        mdl.subscribe.pageView(handler);
-        mdl.publish.pageView({ [contexts.REFERRER_URL_CONTEXT]: myContext });
+        mdl.publish.addToCart(customContext);
     });
 
     test("event context data is not persisted in data layer", () => {


### PR DESCRIPTION
Some events require ids to be passed as arguments when published.

BREAKING CHANGE: The following events now require additional parameters when published:
- recsItemAddToCartClick
- recsItemClick
- recsUnitRender
- recsUnitView
- searchCategoryClick
- searchProductClick
- searchSuggestionClick

SEARCH-1326

## Description

Accept additional parameters for some events to properly identify context data.

## Related Issue

[SEARCH-1326](https://jira.corp.magento.com/browse/SEARCH-1326)

## Motivation and Context

Without more information, the event handlers wouldn't know _which_ part of context data to look at. We added additional parameters, like `unitId` and `productId`, to certain `publish` methods to pass that data through.

## How Has This Been Tested?

Tested with `jest`.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
