### PR TITLE
feat: instant purchase event

### DIFF
--- a/example/publish.js
+++ b/example/publish.js
@@ -4,6 +4,7 @@ setTimeout(() => {
     mse.publish.addToCart();
     mse.publish.customUrl();
     mse.publish.initiateCheckout();
+    mse.publish.instantPurchase();
     mse.publish.pageActivitySummary();
     mse.publish.pageView();
     mse.publish.placeOrder();

--- a/example/subscribe.js
+++ b/example/subscribe.js
@@ -4,6 +4,7 @@ const mse = window.magentoStorefrontEvents;
 mse.subscribe.addToCart(args => console.log(args));
 mse.subscribe.customUrl(args => console.log(args));
 mse.subscribe.initiateCheckout(args => console.log(args));
+mse.subscribe.instantPurchase(args => console.log(args));
 mse.subscribe.pageActivitySummary(args => console.log(args));
 mse.subscribe.pageView(args => console.log(args));
 mse.subscribe.placeOrder(args => console.log(args));

--- a/src/PublishManager.ts
+++ b/src/PublishManager.ts
@@ -37,6 +37,13 @@ export default class PublishManager extends Base {
     }
 
     /**
+     * Publish Instant Purchase event
+     */
+    instantPurchase(context?: CustomContext): void {
+        this.pushEvent(events.INSTANT_PURCHASE, { customContext: context });
+    }
+
+    /**
      * Publish Page Activity Summary event
      */
     pageActivitySummary(context?: CustomContext): void {

--- a/src/SubscribeManager.ts
+++ b/src/SubscribeManager.ts
@@ -44,6 +44,13 @@ export default class SubscribeManager extends Base {
     }
 
     /**
+     * Subscribe to Instant Purchase event
+     */
+    instantPurchase(handler: EventHandler, options?: ListenerOptions): void {
+        this.addEventListener(events.INSTANT_PURCHASE, handler, options);
+    }
+
+    /**
      * Subscribe to Page Activity Summary event
      */
     pageActivitySummary(

--- a/src/UnsubscribeManager.ts
+++ b/src/UnsubscribeManager.ts
@@ -44,6 +44,13 @@ export default class UnsubscribeManager extends Base {
     }
 
     /**
+     * Unsubscribe from Instant Purchase event
+     */
+    instantPurchase(handler: EventHandler): void {
+        this.removeEventListener(events.INSTANT_PURCHASE, handler);
+    }
+
+    /**
      * Unsubscribe from Page Activity Summary event
      */
     pageActivitySummary(handler: EventHandler): void {

--- a/src/events.ts
+++ b/src/events.ts
@@ -9,6 +9,7 @@ const events = {
     DATA_LAYER_CHANGE: "adobeDataLayer:change",
     DATA_LAYER_EVENT: "adobeDataLayer:event",
     INITIATE_CHECKOUT: "initiate-checkout",
+    INSTANT_PURCHASE: "instant-purchase",
     PAGE_ACTIVITY_SUMMARY: "page-activity-summary",
     PAGE_VIEW: "page-view",
     PLACE_ORDER: "place-order",

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -12,6 +12,7 @@ export type EventName =
     | typeof events.DATA_LAYER_CHANGE
     | typeof events.DATA_LAYER_EVENT
     | typeof events.INITIATE_CHECKOUT
+    | typeof events.INSTANT_PURCHASE
     | typeof events.PAGE_ACTIVITY_SUMMARY
     | typeof events.PAGE_VIEW
     | typeof events.PLACE_ORDER

--- a/tests/events.test.ts
+++ b/tests/events.test.ts
@@ -76,6 +76,23 @@ describe("events", () => {
         expect(eventHandler).toHaveBeenCalledTimes(1);
     });
 
+    test("instant purchase", async () => {
+        const eventHandler = jest.fn(eventObj => {
+            expect(eventObj).toEqual({
+                event: events.INSTANT_PURCHASE,
+                eventInfo: expect.any(Object),
+            });
+        });
+
+        mdl.subscribe.instantPurchase(eventHandler);
+        expect(eventHandler).not.toHaveBeenCalled();
+        mdl.publish.instantPurchase();
+        expect(eventHandler).toHaveBeenCalledTimes(1);
+        mdl.unsubscribe.instantPurchase(eventHandler);
+        mdl.publish.instantPurchase();
+        expect(eventHandler).toHaveBeenCalledTimes(1);
+    });
+
     test("page activity summary", async () => {
         const eventHandler = jest.fn(eventObj => {
             expect(eventObj).toEqual({


### PR DESCRIPTION
SEARCH-1411

## Description

Support the `instant-purchase` event.

## Related Issue

[SEARCH-1411](https://jira.corp.magento.com/browse/SEARCH-1411)

## Motivation and Context

This event was implemented in the legacy Snowplow collector, but not included in our wiki specification. This PR brings everything in line.

## How Has This Been Tested?

Tested with `jest` as well as with the local `example` directory.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
