### PR TITLE
fix: remove tracker build number

### DIFF
--- a/src/types/schemas/magentoJsTracker.ts
+++ b/src/types/schemas/magentoJsTracker.ts
@@ -5,5 +5,4 @@
 
 export type MagentoJsTracker = {
     magentoJsVersion: string;
-    magentoJsBuild: string;
 };


### PR DESCRIPTION
BREAKING CHANGE: The magentoJsBuild field in the MagentoJsTracker context has been removed.

## Description

Removing the unused `magentoJsBuild` property in the `Tracker` context.

## Related Issue

N/A

## Motivation and Context

We are building with GitHub Actions instead of Jenkins, and therefore have no need for the build number.

## How Has This Been Tested?

Tested with `jest`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
