### PR TITLE
feat: add category context

### DIFF
--- a/src/ContextManager.ts
+++ b/src/ContextManager.ts
@@ -6,21 +6,37 @@
 import { Base } from "./Base";
 import contexts from "./contexts";
 import {
+    Category,
+    CustomUrl,
     MagentoExtension,
+    Order,
     Page,
     Product,
     Shopper,
-    StorefrontInstance,
     ShoppingCart,
-    CustomUrl,
+    StorefrontInstance,
     Recommendations,
     ReferrerUrl,
     SearchInput,
     SearchResults,
-    Order,
 } from "./types/schemas";
 
 export default class ContextManager extends Base {
+    /**
+     * Get url context
+     */
+    getCategory(): Category {
+        return this.getContext<Category>(contexts.CATEGORY_CONTEXT);
+    }
+
+    /**
+     * Set url context
+     * @param context
+     */
+    setCategory(context: Category): void {
+        this.setContext<Category>(contexts.CATEGORY_CONTEXT, context);
+    }
+
     /**
      * Get url context
      */

--- a/src/contexts.ts
+++ b/src/contexts.ts
@@ -4,6 +4,7 @@
  */
 
 const contexts = {
+    CATEGORY_CONTEXT: "categoryContext",
     CUSTOM_URL_CONTEXT: "customUrlContext",
     MAGENTO_EXTENSION_CONTEXT: "magentoExtensionContext",
     ORDER_CONTEXT: "orderContext",

--- a/src/types/contexts.ts
+++ b/src/types/contexts.ts
@@ -5,6 +5,7 @@
 
 import contexts from "../contexts";
 import {
+    Category,
     CustomUrl,
     MagentoExtension,
     Order,
@@ -20,6 +21,7 @@ import {
 } from "./schemas";
 
 export type ContextName =
+    | typeof contexts.CATEGORY_CONTEXT
     | typeof contexts.CUSTOM_URL_CONTEXT
     | typeof contexts.MAGENTO_EXTENSION_CONTEXT
     | typeof contexts.ORDER_CONTEXT
@@ -34,6 +36,7 @@ export type ContextName =
     | typeof contexts.STOREFRONT_INSTANCE_CONTEXT;
 
 export type Context = {
+    [contexts.CATEGORY_CONTEXT]: Category;
     [contexts.CUSTOM_URL_CONTEXT]: CustomUrl;
     [contexts.MAGENTO_EXTENSION_CONTEXT]: MagentoExtension;
     [contexts.ORDER_CONTEXT]: Order;

--- a/src/types/schemas/category.ts
+++ b/src/types/schemas/category.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+export type Category = {
+    name: string;
+    urlKey: string;
+    urlPath: string;
+};

--- a/src/types/schemas/index.ts
+++ b/src/types/schemas/index.ts
@@ -1,4 +1,5 @@
 export * from "./billingAddress";
+export * from "./category";
 export * from "./customUrl";
 export * from "./experiment";
 export * from "./giftCard";

--- a/tests/contexts.test.ts
+++ b/tests/contexts.test.ts
@@ -5,6 +5,7 @@
 
 import mdl, { MagentoStorefrontEvents } from "../src/index";
 import {
+    generateCategoryContext,
     generateCustomContext,
     generateCustomUrlContext,
     generateMagentoExtensionContext,
@@ -37,6 +38,13 @@ test("data layer should exist", () => {
 });
 
 describe("contexts", () => {
+    test("category context", () => {
+        const context = generateCategoryContext();
+        expect(mdl.context.getCategory()).toBeUndefined();
+        mdl.context.setCategory(context);
+        expect(mdl.context.getCategory()).toEqual(context);
+    });
+
     test("custom url context", () => {
         const context = generateCustomUrlContext();
         expect(mdl.context.getCustomUrl()).toBeUndefined();

--- a/tests/mocks.ts
+++ b/tests/mocks.ts
@@ -5,6 +5,7 @@
 
 import { CustomUrl } from "../src/types/schemas/customUrl";
 import {
+    Category,
     MagentoExtension,
     Order,
     Page,
@@ -18,6 +19,15 @@ import {
     StorefrontInstance,
 } from "../src/types/schemas/";
 import { CustomContext } from "../src/types/contexts";
+
+export const generateCategoryContext = (
+    overrides?: Partial<Category>,
+): Category => ({
+    name: "pants",
+    urlKey: "pants",
+    urlPath: "/categories/pants",
+    ...overrides,
+});
 
 export const generateCustomUrlContext = (
     overrides?: Partial<CustomUrl>,


### PR DESCRIPTION
SEARCH-1425

## Description

Added a `Category` context to the SDK.

## Related Issue

[SEARCH-1425](https://jira.corp.magento.com/browse/SEARCH-1425)

## Motivation and Context

The Product Recommendations team leverages category information that should be stored somewhere where all consumers have access. Adding a `Category` context makes sense for this use case.

## How Has This Been Tested?

Tested with `jest` and the `example` directory.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
