### PR TITLE
fix: require more properties to match snowplow schema

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,16 @@
+<!--- STOP! Before you open an issue please search this repository's issues to see if it has already been reported. This helps reduce duplicate issues from being created. -->
+<!--- SECURITY DISCLOSURE: If this is a security disclosure please follow the guidelines in CONTRIBUTING.md. This helps keep folks from accidentally releasing vulnerabilities before the maintainers get a chance to fix the issue. -->
+
+### Expected Behaviour
+
+### Actual Behaviour
+
+### Reproduce Scenario (including but not limited to)
+
+#### Steps to Reproduce
+
+#### Platform and Version
+
+#### Sample Code that illustrates the problem
+
+#### Logs taken while reproducing problem

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,45 @@
+<!--- Provide a general summary of your changes in the Title above -->
+
+## Description
+
+<!--- Describe your changes in detail -->
+
+## Related Issue
+
+<!--- This project only accepts pull requests related to open issues -->
+<!--- If suggesting a new feature or change, please discuss it in an issue first -->
+<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
+<!--- Please link to the issue here: -->
+
+## Motivation and Context
+
+<!--- Why is this change required? What problem does it solve? -->
+
+## How Has This Been Tested?
+
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
+
+## Screenshots (if appropriate):
+
+## Types of changes
+
+<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+
+-   [ ] Bug fix (non-breaking change which fixes an issue)
+-   [ ] New feature (non-breaking change which adds functionality)
+-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
+
+## Checklist
+
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+
+-   [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
+-   [ ] My code follows the code style of this project.
+-   [ ] My change requires a change to the documentation.
+-   [ ] I have updated the documentation accordingly.
+-   [ ] I have read the **CONTRIBUTING** document.
+-   [ ] I have added tests to cover my changes.
+-   [ ] All new and existing tests passed.

--- a/src/types/schemas/product.ts
+++ b/src/types/schemas/product.ts
@@ -6,7 +6,7 @@
 export type Product = {
     productId: number;
     name: string;
-    sku: string | null;
+    sku: string;
     topLevelSku?: string | null;
     specialToDate?: string | null;
     specialFromDate?: string | null;
@@ -18,12 +18,12 @@ export type Product = {
     countryOfManufacture?: string | null;
     categories?: string[] | null;
     productType?: string | null;
-    pricing?: {
+    pricing: {
         regularPrice: number;
         minimalPrice: number;
         maximalPrice: number;
-        specialPrice: number;
-        tierPricing: {
+        specialPrice?: number;
+        tierPricing?: {
             customerGroupId?: number | null;
             qty: number;
             value: number;

--- a/src/types/schemas/shoppingCart.ts
+++ b/src/types/schemas/shoppingCart.ts
@@ -24,12 +24,12 @@ type ShoppingCartItem = {
     canApplyMsrp: boolean;
     formattedPrice: string;
     id: string;
-    prices?: {
+    prices: {
         price: Price;
     };
     product: Product;
     configurableOptions?: Array<ConfigurableOption>;
-    quantity?: number;
+    quantity: number;
 };
 
 type ConfigurableOption = {

--- a/tests/mocks.ts
+++ b/tests/mocks.ts
@@ -77,6 +77,12 @@ export const generateProductContext = (
     productId: 1153,
     sku: "VD04",
     topLevelSku: "VD04",
+    pricing: {
+        regularPrice: 19.99,
+        minimalPrice: 10.99,
+        maximalPrice: 24.99,
+        currencyCode: "USD",
+    },
     ...overrides,
 });
 
@@ -246,7 +252,32 @@ export const generateShoppingCartContext = (
     overrides?: Partial<ShoppingCart>,
 ): ShoppingCart => ({
     id: "1",
-    items: [],
+    items: [
+        {
+            canApplyMsrp: false,
+            formattedPrice: "$20.00",
+            id: "aaaaaa",
+            prices: {
+                price: {
+                    value: 20.0,
+                    currency: "USD",
+                },
+            },
+            product: {
+                productId: 111111,
+                name: "T-Shirt",
+                sku: "ts001",
+                pricing: {
+                    regularPrice: 20.0,
+                    minimalPrice: 20.0,
+                    maximalPrice: 20.0,
+                    currencyCode: "USD",
+                },
+            },
+            configurableOptions: [],
+            quantity: 1,
+        },
+    ],
     prices: {
         subtotalExcludingTax: {
             value: 19.99,


### PR DESCRIPTION
BREAKING CHANGE: The product.sku and product.pricing are now required. Same with the
shoppingCart.item.prices and the shoppingCart.item.quantity.

SEARCH-1441

## Description

Required more properties in the `Product` and `ShoppingCart` context.

## Related Issue

[SEARCH-1441](https://jira.corp.magento.com/browse/SEARCH-1441)

## Motivation and Context

Snowplow modeling requires certain fields. The SDK must ensure they are present in the data layer to prevent event failures.

## How Has This Been Tested?

Tested locally with `jest`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
