### PR TITLE
feat: add sourcemaps in dev and qa. broadcast message when available

### DIFF
--- a/.github/workflows/merge-to-main.yml
+++ b/.github/workflows/merge-to-main.yml
@@ -23,7 +23,7 @@ jobs:
             - name: install
               run: npm ci
             - name: build
-              run: npm run build
+              run: npm run build:qa
             - name: release
               run: npm run release -- --skip.commit --skip.tag --release-as 0.0.0-${{ github.sha }}
             - name: publish

--- a/.github/workflows/publish-latest.yml
+++ b/.github/workflows/publish-latest.yml
@@ -23,7 +23,7 @@ jobs:
             - name: install
               run: npm ci
             - name: build
-              run: npm run build
+              run: npm run build:prod
             - name: publish
               run: npm publish --access public
               env:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -31,4 +31,4 @@ jobs:
             - name: test
               run: npm test
             - name: build
-              run: npm run build
+              run: npm run build:prod

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
             "license": "SEE LICENSE IN LICENSE",
             "devDependencies": {
                 "@adobe/adobe-client-data-layer": "^2.0.1",
+                "@testing-library/dom": "^7.31.2",
                 "@types/jest": "^26.0.23",
                 "@typescript-eslint/eslint-plugin": "^4.2.0",
                 "@typescript-eslint/parser": "^4.2.0",
@@ -400,6 +401,25 @@
             },
             "peerDependencies": {
                 "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/runtime": {
+            "version": "7.14.0",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
+            "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
+            "dev": true,
+            "dependencies": {
+                "regenerator-runtime": "^0.13.4"
+            }
+        },
+        "node_modules/@babel/runtime-corejs3": {
+            "version": "7.14.0",
+            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.14.0.tgz",
+            "integrity": "sha512-0R0HTZWHLk6G8jIk0FtoX+AatCtKnswS98VhXwGImFc759PJRp4Tru0PQYZofyijTFUr+gT8Mu7sgXVJLQ0ceg==",
+            "dev": true,
+            "dependencies": {
+                "core-js-pure": "^3.0.0",
+                "regenerator-runtime": "^0.13.4"
             }
         },
         "node_modules/@babel/template": {
@@ -1552,6 +1572,101 @@
                 "@sinonjs/commons": "^1.7.0"
             }
         },
+        "node_modules/@testing-library/dom": {
+            "version": "7.31.2",
+            "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.31.2.tgz",
+            "integrity": "sha512-3UqjCpey6HiTZT92vODYLPxTBWlM8ZOOjr3LX5F37/VRipW2M1kX6I/Cm4VXzteZqfGfagg8yXywpcOgQBlNsQ==",
+            "dev": true,
+            "dependencies": {
+                "@babel/code-frame": "^7.10.4",
+                "@babel/runtime": "^7.12.5",
+                "@types/aria-query": "^4.2.0",
+                "aria-query": "^4.2.2",
+                "chalk": "^4.1.0",
+                "dom-accessibility-api": "^0.5.6",
+                "lz-string": "^1.4.4",
+                "pretty-format": "^26.6.2"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@testing-library/dom/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/@testing-library/dom/node_modules/chalk": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+            "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/@testing-library/dom/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/@testing-library/dom/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true
+        },
+        "node_modules/@testing-library/dom/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@testing-library/dom/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@types/aria-query": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.1.tgz",
+            "integrity": "sha512-S6oPal772qJZHoRZLFc/XoZW2gFvwXusYUmXPXkgxJLuEk2vOt7jc4Yo6z/vtI0EBkbPBVrJJ0B+prLIKiWqHg==",
+            "dev": true
+        },
         "node_modules/@types/babel__core": {
             "version": "7.1.14",
             "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.14.tgz",
@@ -2295,6 +2410,19 @@
             "dev": true,
             "dependencies": {
                 "sprintf-js": "~1.0.2"
+            }
+        },
+        "node_modules/aria-query": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
+            "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
+            "dev": true,
+            "dependencies": {
+                "@babel/runtime": "^7.10.2",
+                "@babel/runtime-corejs3": "^7.10.2"
+            },
+            "engines": {
+                "node": ">=6.0"
             }
         },
         "node_modules/arr-diff": {
@@ -4025,6 +4153,17 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/core-js-pure": {
+            "version": "3.13.1",
+            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.13.1.tgz",
+            "integrity": "sha512-wVlh0IAi2t1iOEh16y4u1TRk6ubd4KvLE8dlMi+3QUI6SfKphQUh7tAwihGGSQ8affxEXpVIPpOdf9kjR4v4Pw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/core-js"
+            }
+        },
         "node_modules/core-util-is": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -4521,6 +4660,12 @@
             "engines": {
                 "node": ">=6.0.0"
             }
+        },
+        "node_modules/dom-accessibility-api": {
+            "version": "0.5.6",
+            "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.6.tgz",
+            "integrity": "sha512-DplGLZd8L1lN64jlT27N9TVSESFR5STaEJvX+thCby7fuCHonfPpAlodYc3vuUYbDuDec5w8AMP7oCM5TWFsqw==",
+            "dev": true
         },
         "node_modules/dom-converter": {
             "version": "0.2.0",
@@ -10235,6 +10380,15 @@
                 "node": ">=10"
             }
         },
+        "node_modules/lz-string": {
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
+            "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
+            "dev": true,
+            "bin": {
+                "lz-string": "bin/bin.js"
+            }
+        },
         "node_modules/make-dir": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -11822,6 +11976,12 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/regenerator-runtime": {
+            "version": "0.13.7",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+            "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+            "dev": true
         },
         "node_modules/regex-not": {
             "version": "1.0.2",
@@ -15860,6 +16020,25 @@
                 "@babel/helper-plugin-utils": "^7.12.13"
             }
         },
+        "@babel/runtime": {
+            "version": "7.14.0",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
+            "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
+            "dev": true,
+            "requires": {
+                "regenerator-runtime": "^0.13.4"
+            }
+        },
+        "@babel/runtime-corejs3": {
+            "version": "7.14.0",
+            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.14.0.tgz",
+            "integrity": "sha512-0R0HTZWHLk6G8jIk0FtoX+AatCtKnswS98VhXwGImFc759PJRp4Tru0PQYZofyijTFUr+gT8Mu7sgXVJLQ0ceg==",
+            "dev": true,
+            "requires": {
+                "core-js-pure": "^3.0.0",
+                "regenerator-runtime": "^0.13.4"
+            }
+        },
         "@babel/template": {
             "version": "7.12.13",
             "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
@@ -16744,6 +16923,79 @@
                 "@sinonjs/commons": "^1.7.0"
             }
         },
+        "@testing-library/dom": {
+            "version": "7.31.2",
+            "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.31.2.tgz",
+            "integrity": "sha512-3UqjCpey6HiTZT92vODYLPxTBWlM8ZOOjr3LX5F37/VRipW2M1kX6I/Cm4VXzteZqfGfagg8yXywpcOgQBlNsQ==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.10.4",
+                "@babel/runtime": "^7.12.5",
+                "@types/aria-query": "^4.2.0",
+                "aria-query": "^4.2.2",
+                "chalk": "^4.1.0",
+                "dom-accessibility-api": "^0.5.6",
+                "lz-string": "^1.4.4",
+                "pretty-format": "^26.6.2"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+                    "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
+        "@types/aria-query": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.1.tgz",
+            "integrity": "sha512-S6oPal772qJZHoRZLFc/XoZW2gFvwXusYUmXPXkgxJLuEk2vOt7jc4Yo6z/vtI0EBkbPBVrJJ0B+prLIKiWqHg==",
+            "dev": true
+        },
         "@types/babel__core": {
             "version": "7.1.14",
             "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.14.tgz",
@@ -17348,6 +17600,16 @@
             "dev": true,
             "requires": {
                 "sprintf-js": "~1.0.2"
+            }
+        },
+        "aria-query": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
+            "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
+            "dev": true,
+            "requires": {
+                "@babel/runtime": "^7.10.2",
+                "@babel/runtime-corejs3": "^7.10.2"
             }
         },
         "arr-diff": {
@@ -18724,6 +18986,12 @@
             "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
             "dev": true
         },
+        "core-js-pure": {
+            "version": "3.13.1",
+            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.13.1.tgz",
+            "integrity": "sha512-wVlh0IAi2t1iOEh16y4u1TRk6ubd4KvLE8dlMi+3QUI6SfKphQUh7tAwihGGSQ8affxEXpVIPpOdf9kjR4v4Pw==",
+            "dev": true
+        },
         "core-util-is": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -19102,6 +19370,12 @@
             "requires": {
                 "esutils": "^2.0.2"
             }
+        },
+        "dom-accessibility-api": {
+            "version": "0.5.6",
+            "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.6.tgz",
+            "integrity": "sha512-DplGLZd8L1lN64jlT27N9TVSESFR5STaEJvX+thCby7fuCHonfPpAlodYc3vuUYbDuDec5w8AMP7oCM5TWFsqw==",
+            "dev": true
         },
         "dom-converter": {
             "version": "0.2.0",
@@ -23481,6 +23755,12 @@
                 "yallist": "^4.0.0"
             }
         },
+        "lz-string": {
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
+            "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
+            "dev": true
+        },
         "make-dir": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -24685,6 +24965,12 @@
                 "indent-string": "^4.0.0",
                 "strip-indent": "^3.0.0"
             }
+        },
+        "regenerator-runtime": {
+            "version": "0.13.7",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+            "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+            "dev": true
         },
         "regex-not": {
             "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "packages": {
         "": {
             "name": "@adobe/magento-storefront-events-sdk",
-            "version": "0.15.1",
+            "version": "0.17.0",
             "license": "SEE LICENSE IN LICENSE",
             "devDependencies": {
                 "@adobe/adobe-client-data-layer": "^2.0.1",
@@ -29,7 +29,8 @@
                 "typescript": "^4.0.3",
                 "webpack": "^5.26.2",
                 "webpack-cli": "^4.5.0",
-                "webpack-dev-server": "^4.0.0-beta.0"
+                "webpack-dev-server": "^4.0.0-beta.0",
+                "webpack-merge": "^5.7.3"
             }
         },
         "node_modules/@adobe/adobe-client-data-layer": {

--- a/package.json
+++ b/package.json
@@ -9,8 +9,11 @@
         "dist/"
     ],
     "scripts": {
-        "start": "webpack serve",
-        "build": "webpack --config webpack.config.js",
+        "start": "webpack serve --config webpack.dev.js",
+        "build": "webpack --config webpack.prod.js",
+        "build:dev": "webpack --config webpack.dev.js",
+        "build:qa": "webpack --config webpack.qa.js",
+        "build:prod": "webpack --config webpack.prod.js",
         "lint": "eslint .",
         "lint:fix": "eslint --fix .",
         "format": "prettier --check \"./**/*.{ts,tsx,js,css,json,md}\"",
@@ -55,7 +58,8 @@
         "typescript": "^4.0.3",
         "webpack": "^5.26.2",
         "webpack-cli": "^4.5.0",
-        "webpack-dev-server": "^4.0.0-beta.0"
+        "webpack-dev-server": "^4.0.0-beta.0",
+        "webpack-merge": "^5.7.3"
     },
     "husky": {
         "hooks": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "homepage": "https://github.com/adobe/magento-storefront-events-sdk#readme",
     "devDependencies": {
         "@adobe/adobe-client-data-layer": "^2.0.1",
+        "@testing-library/dom": "^7.31.2",
         "@types/jest": "^26.0.23",
         "@typescript-eslint/eslint-plugin": "^4.2.0",
         "@typescript-eslint/parser": "^4.2.0",

--- a/src/MagentoStorefrontEvents.ts
+++ b/src/MagentoStorefrontEvents.ts
@@ -12,26 +12,21 @@ class MagentoStorefrontEvents {
     constructor() {
         // ensure event array is available
         window.adobeDataLayer = window.adobeDataLayer || [];
+
+        // broadcast availability
+        window.postMessage("magento-storefront-events-sdk", "*");
     }
 
-    /**
-     * Methods for interacting with context data
-     */
+    // Methods for interacting with context data
     public context = new ContextManager();
 
-    /**
-     * Methods for publishing events
-     */
+    // Methods for publishing events
     public publish = new PublishManager();
 
-    /**
-     * Methods for subscribing to events
-     */
+    // Methods for subscribing to events
     public subscribe = new SubscribeManager();
 
-    /**
-     * Methods for unsubscribing from events
-     */
+    // Methods for unsubscribing from events
     public unsubscribe = new UnsubscribeManager();
 }
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -4,6 +4,7 @@
  */
 
 import mdl, { MagentoStorefrontEvents } from "../src/index";
+import { waitFor } from "@testing-library/dom";
 
 beforeAll(() => {
     // Forces magento data layer code to be bundled so that
@@ -19,4 +20,19 @@ beforeEach(async () => {
 
 test("data layer should exist", () => {
     expect(window.adobeDataLayer).toBeDefined();
+});
+
+test("broadcasts message", async () => {
+    const handlerMock = jest.fn();
+    window.addEventListener("message", handlerMock, false);
+
+    await waitFor(() => {
+        expect(handlerMock).toHaveBeenCalledTimes(1);
+
+        expect(handlerMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                data: "magento-storefront-events-sdk",
+            }),
+        );
+    });
 });

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,8 +1,11 @@
 const path = require("path");
+const webpack = require("webpack");
+const { name, version } = require("./package.json");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 
+const banner = `${name}@v${version}`;
+
 const config = {
-    mode: "production",
     entry: "./src/index.ts",
     output: {
         filename: "index.js",
@@ -25,7 +28,7 @@ const config = {
             },
         ],
     },
-    plugins: [new HtmlWebpackPlugin()],
+    plugins: [new HtmlWebpackPlugin(), new webpack.BannerPlugin(banner)],
     resolve: {
         extensions: [".ts", ".tsx", ".js", ".jsx", ".json"],
     },

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,0 +1,7 @@
+const { merge } = require("webpack-merge");
+const common = require("./webpack.common.js");
+
+module.exports = merge(common, {
+    mode: "development",
+    devtool: "eval-source-map",
+});

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -1,0 +1,6 @@
+const { merge } = require("webpack-merge");
+const common = require("./webpack.common.js");
+
+module.exports = merge(common, {
+    mode: "production",
+});

--- a/webpack.qa.js
+++ b/webpack.qa.js
@@ -1,0 +1,7 @@
+const { merge } = require("webpack-merge");
+const common = require("./webpack.common.js");
+
+module.exports = merge(common, {
+    mode: "development",
+    devtool: "eval-source-map",
+});


### PR DESCRIPTION
## Description

Broadcasts a message on `window` when the SDK loads.

## Related Issue

N/A

## Motivation and Context

This change allows the SDK and the Collector to be loaded with `async` tags and still operate normally no matter which script executes first.

## How Has This Been Tested?

Tested locally with `jest` and the `example` directory.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [x] I have read the **CONTRIBUTING** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
