### PR TITLE
fix: make price optional to support b2b

### DIFF
--- a/src/types/schemas/recommendations.ts
+++ b/src/types/schemas/recommendations.ts
@@ -33,13 +33,13 @@ export type RecommendedProduct = {
     categories: Array<string>;
     weight: number;
     weightType?: string | null;
-    currency: string;
+    currency?: string;
     image?: Image | null;
     smallImage?: Image | null;
     thumbnailImage?: Image | null;
     swatchImage?: string | null;
     url: string;
-    prices: Prices;
+    prices?: Prices;
     queryType: string;
 };
 

--- a/src/types/schemas/searchResults.ts
+++ b/src/types/schemas/searchResults.ts
@@ -23,7 +23,7 @@ export type SearchResultProduct = {
     sku: string;
     url: string;
     imageUrl: string;
-    price: number;
+    price?: number;
     rank: number;
 };
 


### PR DESCRIPTION
## Description

Make `price` and `currencyCode` optional.

## Related Issue

[DATA-3400](https://jira.corp.magento.com/browse/DATA-3400)

## Motivation and Context

Enables customer group pricing for B2B.

## How Has This Been Tested?

Ran existing `jest` tests.

## Types of changes

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

-   [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
-   [X] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [X] I have read the **CONTRIBUTING** document.
-   [ ] I have added tests to cover my changes.
-   [X] All new and existing tests passed.
